### PR TITLE
[BACKLOG-312] - Adding missing bundles to the pentaho-metaverse-ee feature

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -143,6 +143,10 @@
     <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/2.3.3</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/2.3.3</bundle>
 
+    <bundle>mvn:org.codehaus.jackson/jackson-core-asl/1.9.13</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.13</bundle>
+    <bundle>mvn:org.codehaus.jackson/jackson-jaxrs/1.9.13</bundle>
+
     <bundle>mvn:com.pentaho/pentaho-metaverse-ee/${project.version}</bundle>
   </feature>
 


### PR DESCRIPTION
[BACKLOG-312] - Adding missing bundles to the pentaho-metaverse-ee feature