### PR TITLE
[BACKLOG-2726] - removing org.pentaho.platform.api.metaverse from the sy...

### DIFF
--- a/src/main/filtered-resources/etc/custom.properties
+++ b/src/main/filtered-resources/etc/custom.properties
@@ -254,7 +254,6 @@ org.osgi.framework.system.packages.extra= \
  org.springframework.security.context, \
  org.pentaho.platform.api.repository2.unified, \
  org.pentaho.platform.api.repository, \
- org.pentaho.platform.api.metaverse, \
  org.pentaho.platform.repository2, \
  org.pentaho.platform.util.messages, \
  org.pentaho.platform.engine.core.system.objfac, \


### PR DESCRIPTION
...stem packages now that it no longer is in platform-api. the metaverse API is now all in the pentaho-metaverse bundle.