### PR TITLE
[BACKLOG-3184] Provide different(client and server) port configurations ...

### DIFF
--- a/src/main/descriptors/pentaho-client-assembly.xml
+++ b/src/main/descriptors/pentaho-client-assembly.xml
@@ -33,6 +33,7 @@
         <exclude>etc/custom.properties</exclude>
         <exclude>etc/startup.properties</exclude>
         <exclude>etc/org.apache.karaf.features.cfg</exclude>
+        <exclude>etc/org.apache.karaf.management.cfg</exclude>
         <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
         <exclude>etc/org.apache.karaf.shell.cfg</exclude>
         <exclude>etc/system.properties</exclude>

--- a/src/main/filtered-resources/etc-client/org.apache.karaf.management.cfg
+++ b/src/main/filtered-resources/etc-client/org.apache.karaf.management.cfg
@@ -1,0 +1,70 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# The properties in this file define the configuration of Apache Karaf's JMX Management
+#
+
+#
+# Port number for RMI registry connection
+#
+rmiRegistryPort = 1098
+
+#
+# Host for RMI registry
+#
+rmiRegistryHost = 0.0.0.0
+
+#
+# Port number for RMI server connection
+#
+rmiServerPort = 44443
+
+rmiServerHost = 0.0.0.0
+
+#
+# Name of the JAAS realm used for authentication
+#
+jmxRealm = karaf
+
+#
+# The service URL for the JMXConnectorServer
+#
+serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
+
+#
+# Whether any threads started for the JMXConnectorServer should be started as daemon threads
+#
+daemon = true
+
+#
+# Whether the JMXConnectorServer should be started in a separate thread
+#
+threaded = true
+
+#
+# The ObjectName used to register the JMXConnectorServer
+#
+objectName = connector:name=rmi
+
+#
+# Role name used for JMX access authorization
+# If not set, this defaults to the ${karaf.admin.role} configured in etc/system.properties
+#
+# jmxRole=admin


### PR DESCRIPTION
...for all the ports karaf uses

	- apache-karaf dependency embeds a JMX MBeanServer, configurable via etc/org.apache.karaf.management.cfg file
	- http://karaf.apache.org/manual/latest/users-guide/monitoring.html
	- in client-assembly excluded org.apache.karaf.management.cfg, and added one of our own in filtered-resources/etc-client
	- this added org.apache.karaf.management.cfg declares slightly different ports
	- karaf-server builds remains unaltered