### PR TITLE
[BACKLOG-3790] Exclude karaf.management.cfg from distribution so two …

### DIFF
--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-server-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-server-assembly.xml
@@ -31,6 +31,7 @@
       <outputDirectory>/</outputDirectory>
       <excludes>
         <exclude>etc/custom.properties</exclude>
+        <exclude>etc/org.apache.karaf.management.cfg</exclude>
         <exclude>etc/org.apache.karaf.features.cfg</exclude>
         <exclude>etc/org.ops4j.pax.url.mvn.cfg</exclude>
         <exclude>etc/startup.properties</exclude>


### PR DESCRIPTION
…files are not written to zip