### PR TITLE
[CLEANUP] - Commenting out the Big Data dependency

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -41,7 +41,7 @@
 <feature name="pentaho-client" version="1.0">
     <feature>pentaho-base</feature>
     <feature>pentaho-cache-system</feature>
-    <feature>pentaho-big-data-plugin-osgi</feature>
+    <!--<feature>pentaho-big-data-plugin-osgi</feature>-->
     <bundle>mvn:pentaho/pentaho-osgi-utils-impl/${project.version}</bundle>
     <bundle>mvn:pentaho/pentaho-mongo-utils/${project.version}</bundle>
     <bundle>wrap:mvn:pentaho/pentaho-mongodb-plugin/${project.version}</bundle>


### PR DESCRIPTION
Pentaho Client is depending on the big data plugin, right now the plugin is not working and this is preventing the server from starting.