### PR TITLE
[BACKLOG-4406] Some Data Service windows lost their icon (in the title bar)

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -222,14 +222,15 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.di.trans.step, \
  org.pentaho.di.ui.core, \
  org.pentaho.di.ui.core.dialog, \
- org.pentaho.di.ui.core.widget, \
- org.pentaho.di.ui.trans.dialog, \
- org.pentaho.di.ui.trans.step, \
- org.pentaho.di.ui.xul.common.preview, \
  org.pentaho.di.ui.core.gui, \
+ org.pentaho.di.ui.core.widget, \
  org.pentaho.di.ui.repository, \
  org.pentaho.di.ui.repository.repositoryexplorer.model, \
+ org.pentaho.di.ui.trans.dialog, \
+ org.pentaho.di.ui.trans.step, \
  org.pentaho.di.ui.util, \
+ org.pentaho.di.ui.xul, \
+ org.pentaho.di.ui.xul.common.preview, \
  org.pentaho.metastore.api, \
  org.pentaho.metastore.api.exceptions, \
  org.pentaho.metastore.persist, \


### PR DESCRIPTION
Add org.pentaho.di.ui.xul which exports KettleXulLoader class