### PR TITLE
[BACKLOG-5216] - PMR libraries staging archive lacks some pentaho karaf features

### DIFF
--- a/pentaho-karaf-assembly/pom.xml
+++ b/pentaho-karaf-assembly/pom.xml
@@ -210,7 +210,10 @@
                 <feature>ssh</feature>
                 <feature>kar</feature>
                 <feature>http</feature>
+                <feature>cxf</feature>
                 <feature>war</feature>
+                <feature>pentaho-base</feature>
+                <feature>pentaho-client</feature>
               </features>
               <repository>target/pentaho-pmr-features-repo</repository>
             </configuration>


### PR DESCRIPTION
Add missing features.
An attempt has been made to make it as close to kettle-client as it's possible:
only three features were skipped: dataservice, metaverse and marketplace
apparently they are not needed on pmr runtime

@dkincade @brosander 