### PR TITLE
[BACKLOG-5857] - Loading log4j from system classloader

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -57,6 +57,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version\="3.0.3", \
  org.apache.karaf.util.maven; version\="3.0.3", \
+ org.apache.log4j; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
  org.apache.xerces.*; version\="2.11.0", \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -59,6 +59,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version\="3.0.3", \
  org.apache.karaf.util.maven; version\="3.0.3", \
+ org.apache.log4j; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
  org.apache.xerces.*; version\="2.11.0", \

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -26,7 +26,6 @@
     <bundle>mvn:commons-io/commons-io/2.4</bundle>
     <bundle>mvn:commons-lang/commons-lang/2.6</bundle>
     <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
-    <bundle>mvn:log4j/log4j/1.2.17</bundle>
     <bundle>mvn:pentaho/pentaho-platform-plugin-deployer/${project.version}</bundle>
     <feature version="${project.version}">pentaho-webjars-deployer</feature>
   </feature>
@@ -35,7 +34,6 @@
     <feature>pentaho-deployers</feature>
     <feature>pentaho-cache-system</feature>
     <bundle>mvn:org.slf4j/osgi-over-slf4j/1.7.7</bundle>
-    <bundle>mvn:log4j/log4j/1.2.17</bundle>
     <bundle>mvn:commons-logging/commons-logging/1.1.3</bundle>
     <bundle>mvn:commons-collections/commons-collections/3.2.2</bundle>
     <bundle>mvn:org.apache.felix/org.apache.felix.http.api/2.3.2</bundle>


### PR DESCRIPTION
Prevents linkage errors when di.core components use it in signature