### PR TITLE
[BACKLOG-5858] Introduce ServiceBarrier backed BarrierBeans

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -93,7 +93,9 @@ org.osgi.framework.system.packages.extra= \
  org.xml.sax.helpers, \
  org.yaml.snakeyaml; version\="1.13", \
  org.dom4j.*, \
- org.dom4j
+ org.dom4j, \
+ org.pentaho.platform.servicecoordination.api.*, \
+ org.pentaho.platform.servicecoordination.impl.*
 
 karaf.shutdown.port=-1
 org.osgi.framework.storage.clean=none


### PR DESCRIPTION
Waits for the jcrRepository Bean to be created before starting the the Karaf 2 minute timeout in KarafFeatureWatcherImpl