### PR TITLE
[BACKLOG-5949] - Setting the bundle context as part of all karaf type…

### DIFF
--- a/pentaho-blueprint-activators/pom.xml
+++ b/pentaho-blueprint-activators/pom.xml
@@ -32,6 +32,11 @@
                   <classifier>server</classifier>
                 </artifact>
                 <artifact>
+                  <file>src/main/resources/standard.xml</file>
+                  <type>xml</type>
+                  <classifier>standard</classifier>
+                </artifact>
+                <artifact>
                   <file>src/main/resources/monitoring-snmp.xml</file>
                   <type>xml</type>
                   <classifier>monitoring-snmp</classifier>

--- a/pentaho-blueprint-activators/src/main/resources/server.xml
+++ b/pentaho-blueprint-activators/src/main/resources/server.xml
@@ -2,10 +2,6 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0">
 
-  <bean id="OSGIActivator" class="org.pentaho.platform.osgi.PentahoOSGIActivator" scope="singleton">
-    <property name="bundleContext" ref="blueprintBundleContext"/>
-  </bean>
-
   <!-- configure LoginModule which integrates with platform security -->
   <jaas:config name="karaf" rank="1">
     <jaas:module className="org.pentaho.platform.osgi.SpringSecurityLoginModule"

--- a/pentaho-blueprint-activators/src/main/resources/standard.xml
+++ b/pentaho-blueprint-activators/src/main/resources/standard.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+           xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0">
+
+  <bean id="OSGIActivator" class="org.pentaho.platform.osgi.PentahoOSGIActivator" scope="singleton">
+    <property name="bundleContext" ref="blueprintBundleContext"/>
+  </bean>
+
+</blueprint>

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -33,6 +33,7 @@
   <feature name="pentaho-base" version="1.0">
     <feature>pentaho-deployers</feature>
     <feature>pentaho-cache-system</feature>
+    <bundle>blueprint:mvn:pentaho/pentaho-blueprint-activators/${project.version}/xml/standard</bundle>
     <bundle>mvn:org.slf4j/osgi-over-slf4j/${osgi.over.slf4j.version}</bundle>
     <bundle>mvn:commons-logging/commons-logging/${commons.logging.version}</bundle>
     <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>


### PR DESCRIPTION
…s (server, client, ...) in the activator.

This is required to allow kettle plugins to use PentahoSystem to register objects into the OSGi container and register them as services. In this particular case, it allows the step analyzers for kettle xml steps in the new plugin to contribute to a service-list used by the metaverse for lineage.