### PR TITLE
[BACKLOG-6057] Revert "[BACKLOG-5942] - Using cxf version in standard

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -167,7 +167,7 @@
     <feature>pentaho-tinkerpop-gremlin</feature>
     <feature>http</feature>
     <feature>http-whiteboard</feature>
-    <feature version="${cxf.karaf.version}">cxf</feature>
+    <feature>cxf</feature>
 
     <bundle>wrap:mvn:net.sf.flexjson/flexjson/${net.sf.flexjson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${com.fasterxml.jackson.core.version}</bundle>


### PR DESCRIPTION
feature"

This reverts commit a0e0e3560c87d7d8dabc62665480387856b14138.