### PR TITLE
[BACKLOG-6866] Exposing package

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -82,6 +82,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.platform.*, \
  org.pentaho.platform.repository2.*, \
  org.pentaho.platform.proxy.*;version\="6.1.0", \
+ org.pentaho.platform.api.monitoring.snmp;version\="6.1.0", \
  org.pentaho.ui.xul.*, \
  org.pentaho.vfs.ui, \
  org.pentaho.xul.swt.tab, \


### PR DESCRIPTION
org.pentaho.platform.api.monitoring.snmp into karaf with version 6.1.0