### PR TITLE
[BACKLOG-8388] - Upgrade Jersey to 1.19.1 across the suite for Java 8 compatibility

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -99,10 +99,10 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.database.*, \
  com.thoughtworks.xstream, \
  com.thoughtworks.xstream.*, \
- com.sun.jersey.api.client;version\="1.16", \
- com.sun.jersey.api.client.*;version\="1.16", \
- com.sun.jersey.core.header;version\="1.16", \
- com.sun.jersey.multipart;version\="1.16", \
+ com.sun.jersey.api.client;version\="1.19.1", \
+ com.sun.jersey.api.client.*;version\="1.19.1", \
+ com.sun.jersey.core.header;version\="1.19.1", \
+ com.sun.jersey.multipart;version\="1.19.1", \
  javax.ws.rs.*;version\="1.1.1", \
  org.dom4j.*, \
  org.dom4j, \


### PR DESCRIPTION
The fix is needed due to using java 1.8, and incompatibility of asm old version (is used by jersey) reading new java 1.8 features 
The following scope of repositories is upgraded(except webdetails): The list is sorted in the order of build team runs

https://github.com/pentaho/pentaho-reporting
https://github.com/pentaho/mondrian
https://github.com/pentaho/pentaho-kettle
https://github.com/pentaho/pentaho-mondrianschemaworkbench-plugins
https://github.com/pentaho/pentaho-platform
https://github.com/webdetails/cpf
https://github.com/pentaho/pentaho-metaverse
https://github.com/pentaho/pdi-platform-utils-plugin
https://github.com/pentaho/pentaho-data-profiling
https://github.com/pentaho/data-access
https://github.com/pentaho/big-data-plugin
https://github.com/pentaho/pentaho-data-refinery
https://github.com/webdetails/cde
https://github.com/webdetails/cpk
https://github.com/webdetails/cda
https://github.com/pentaho/pentaho-platform-plugin-mobile
https://github.com/pentaho/pentaho-karaf-assembly
https://github.com/pentaho/pentaho-karaf-ee-assembly
https://github.com/pentaho/pdi-sdk-plugins
https://github.com/pentaho/pdi-ee-plugin
https://github.com/pentaho/pdi-agile-bi-plugin
https://github.com/pentaho/pentaho-aggdesigner
https://github.com/pentaho/pentaho-metadata-editor