### PR TITLE
[BACKLOG-9781] - Error launching Pentaho Server EE on bundle pdi-data-refinery

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -95,10 +95,10 @@ org.osgi.framework.system.packages.extra= \
  org.yaml.snakeyaml; version\="1.13", \
  org.pentaho.database, \
  org.pentaho.database.*, \
- com.sun.jersey.api.client;version\="1.16", \
- com.sun.jersey.api.client.*;version\="1.16", \
- com.sun.jersey.core.header;version\="1.16", \
- com.sun.jersey.multipart;version\="1.16", \
+ com.sun.jersey.api.client;version\="1.19.1", \
+ com.sun.jersey.api.client.*;version\="1.19.1", \
+ com.sun.jersey.core.header;version\="1.19.1", \
+ com.sun.jersey.multipart;version\="1.19.1", \
  javax.ws.rs.*;version\="1.1.1", \
  org.dom4j.*, \
  org.dom4j, \


### PR DESCRIPTION
fix separate custom.properties for servers in pentaho, this fix actual for bundles that use jersey external libraries as osgi bundle