### PR TITLE
[PPP-3537] - Specifying the version of xstream to import across the o…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -97,8 +97,8 @@ org.osgi.framework.system.packages.extra= \
  org.yaml.snakeyaml; version\="1.13", \
  org.pentaho.database, \
  org.pentaho.database.*, \
- com.thoughtworks.xstream, \
- com.thoughtworks.xstream.*, \
+ com.thoughtworks.xstream;version\="1.4.9", \
+ com.thoughtworks.xstream.*;version\="1.4.9", \
  com.sun.jersey.api.client;version\="1.19.1", \
  com.sun.jersey.api.client.*;version\="1.19.1", \
  com.sun.jersey.core.header;version\="1.19.1", \


### PR DESCRIPTION
…sgi-bridge.

This fixes an issue i found with the latest snapshot where the data-refinery bundle wouldn't start as a result of the xstream upgrade.