### PR TITLE
Backport of PPP-3537 - Specifying the version of xstream to import ac…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -97,8 +97,8 @@ org.osgi.framework.system.packages.extra= \
  org.yaml.snakeyaml; version\="1.13", \
  org.pentaho.database, \
  org.pentaho.database.*, \
- com.thoughtworks.xstream, \
- com.thoughtworks.xstream.*, \
+ com.thoughtworks.xstream;version\="1.4.9", \
+ com.thoughtworks.xstream.*;version\="1.4.9", \
  com.sun.jersey.api.client;version\="1.16", \
  com.sun.jersey.api.client.*;version\="1.16", \
  com.sun.jersey.core.header;version\="1.16", \


### PR DESCRIPTION
…ross the osgi-bridge(6.1 suite).

@DFieldFL, @rfellows, @bmorrise, @pamval, @kurtwalker,  there are no "Publish Model" and "Build Model" in the Spoon in 6.1 version because of the dependency on xstream. So that the PR should be merged as soon as possible.   