### PR TITLE
[BACKLOG-10623] Spring framework and spring security upgrade

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -85,8 +85,8 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.vfs.ui, \
  org.pentaho.xul.swt.tab, \
  org.slf4j.*; version\="1.7.7", \
- org.springframework.dao; version\="2.0.8.RELEASE", \
- org.springframework.security.*; version\="2.0.8.RELEASE", \
+ org.springframework.dao; version\="4.3.2.RELEASE", \
+ org.springframework.security.*; version\="4.1.3.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -94,8 +94,8 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.pentaho.xul.swt.tab, \
  org.pentaho.platform.*, \
  org.slf4j.*; version\="1.7.7", \
- org.springframework.dao; version\="2.0.8.RELEASE", \
- org.springframework.security.*; version\="2.0.8.RELEASE", \
+ org.springframework.dao; version\="4.3.2.RELEASE", \
+ org.springframework.security.*; version\="4.1.3.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
@@ -46,14 +46,12 @@
         <feature>pentaho-base</feature>
         <feature>pentaho-client</feature>
         <feature>http-whiteboard</feature>
-        <feature version="[4,4.1.5)">spring</feature>
+        <feature version="[4,4.3.2]">spring</feature>
         <feature version="3.1.4.RELEASE">spring-security</feature>
 
         <bundle>mvn:pentaho/pentaho-server-bundle/${project.version}</bundle>
 
         <bundle start-level="20">blueprint:mvn:pentaho/pentaho-blueprint-activators/${project.version}/xml/proxy-watcher</bundle>
-        <bundle start-level="20">mvn:pentaho/pentaho-ss4-proxies/${project.version}</bundle>
-        <bundle start-level="20">mvn:pentaho/pentaho-ss2-proxies/${project.version}</bundle>
         <bundle start-level="50">mvn:pentaho/pentaho-proxy-spring4/${project.version}</bundle>
         <bundle>mvn:pentaho/pentaho-server-bundle/${project.version}</bundle>
 


### PR DESCRIPTION
                - Updated the custom.properties to use springframework -
		  4.3.2.RELEASE and springsecurity 4.1.3.RELEASE
		- Updated pentaho-karaf-features-server.xml to remove
		  pentaho-ss4-proxy, pentaho-ss2-proxy
		  and upgraded the version of spring framework and
		  security in pentaho-server feature