### PR TITLE
[SP-2974] - Backport of PPP-3559 - Use of vulnerable component Angula…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
@@ -58,7 +58,6 @@
 
         <feature version="${project.version}">pentaho-requirejs-osgi-manager</feature>
         <bundle>blueprint:mvn:pentaho/pentaho-blueprint-activators/${project.version}/xml/server</bundle>
-        <bundle>mvn:pentaho/pentaho-angular-bundle/${project.version}</bundle>
         <bundle>mvn:org.apache.felix/org.apache.felix.http.bridge/${org.apache.felix.http.version}</bundle>
         <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>
     </feature>


### PR DESCRIPTION
…r.js 1.2.15 CVE-2015-0167 (6.1 Suite)

@CodeOnCoffee, @pamval, here is the backport of https://github.com/pentaho/pentaho-karaf-assembly/pull/225/files to 6.1. Thanks.  