### PR TITLE
[SP-2975] - Backport of PPP-3567 - Use of vulnerable component drools…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -250,4 +250,29 @@
         <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>
     </feature>
 
+	    <!-- Overriding activemq to exclude xtreaam 1.4.7 version  -->
+    <feature name="activemq" description="ActiveMQ broker libraries" version="5.12.0" resolver="(obr)" start-level="50">
+        <feature>http</feature>
+        <feature version="5.10.0">activemq-client</feature>
+        <bundle>mvn:org.apache.activemq/activemq-karaf/5.10.0</bundle>
+        <bundle dependency="true">mvn:org.apache.xbean/xbean-spring/3.16</bundle>
+        <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
+        <bundle dependency='true'>mvn:commons-lang/commons-lang/2.6</bundle>
+        <bundle dependency="true">mvn:commons-codec/commons-codec/1.4</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.velocity/1.7_6</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/1.9.1_1</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/1.9.0</bundle>
+        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_5</bundle>
+        <bundle dependency="true">mvn:joda-time/joda-time/1.6.2</bundle>
+        <!--<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>-->
+        <bundle dependency="true">mvn:org.apache.aries.transaction/org.apache.aries.transaction.manager/1.0.0</bundle>
+        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-j2ee-connector_1.5_spec/2.0.0</bundle>
+        <bundle dependency="true">mvn:org.apache.aries/org.apache.aries.util/1.0.0</bundle>
+        <bundle dependency="true">mvn:org.apache.activemq/activeio-core/3.1.4</bundle>
+        <bundle dependency="true">mvn:org.codehaus.jettison/jettison/1.3.5</bundle>
+        <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/1.9.12</bundle>
+        <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.12</bundle>
+        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.11.0</bundle>
+    </feature>
+	
 </features>


### PR DESCRIPTION
…-core-5.0.1.jar, CVE-2014-8125 (6.1 Suite)

 - removed xstrem as transitive dependency.

@pamval. @mbatchelor, here is backport of https://github.com/pentaho/pentaho-karaf-assembly/commit/6f6e6d42367d73c900176dcb2d6252c7cfbdba75 to 6.1. Thanks.  