### PR TITLE
[BACKLOG-12099] Adds xstream 1.4.9 needed by data-refinery-pdi-plugin

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -198,6 +198,7 @@
     <bundle>wrap:mvn:pentaho/pentaho-modeler/${project.version}</bundle>
 
     <bundle>wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
+    <bundle>mvn:com.thoughtworks.xstream/xstream/${com.thoughtworks.xstream.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${project.version}</bundle>
   </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,5 +55,6 @@
     <plugin.org.apache.maven.plugins.maven-assembly-plugin.version>2.4</plugin.org.apache.maven.plugins.maven-assembly-plugin.version>
     <commons.io.version>2.4</commons.io.version>
     <net.sf.ehcache.version>2.8.3</net.sf.ehcache.version>
+    <com.thoughtworks.xstream.version>1.4.9</com.thoughtworks.xstream.version>
   </properties>
 </project>


### PR DESCRIPTION
@pamval please review.