### PR TITLE
[BACKLOG-12099] - backport to 6.1

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -220,6 +220,7 @@
     <bundle>wrap:mvn:pentaho/pentaho-modeler/${project.version}</bundle>
 
     <bundle>wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
+	<bundle>mvn:com.thoughtworks.xstream/xstream/${com.thoughtworks.xstream.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${project.version}</bundle>
   </feature>
   

--- a/pom.xml
+++ b/pom.xml
@@ -69,5 +69,7 @@
 	<underscorejs.version>1.7.0</underscorejs.version>
 	
 	<springframework-version>3.2.0</springframework-version>
+	
+	<com.thoughtworks.xstream.version>1.4.9</com.thoughtworks.xstream.version>
   </properties>
 </project>


### PR DESCRIPTION
@pamval, it's https://github.com/pentaho/pentaho-karaf-assembly/pull/243 to 6.1. Thanks.