### PR TITLE
[PPP-3506] - XXE Security Vulnerability in xml parsers

### DIFF
--- a/pentaho-karaf-assembly/pom.xml
+++ b/pentaho-karaf-assembly/pom.xml
@@ -12,7 +12,7 @@
   <version>7.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <properties>
-    <eigenbase.xom.version>1.3.4</eigenbase.xom.version>
+    <eigenbase.xom.version>1.3.5</eigenbase.xom.version>
     <commons.lang.version>2.6</commons.lang.version>
     <commons.beanutils.version>1.9.2</commons.beanutils.version>
     <com.github.zafarkhaja.version>0.9.0</com.github.zafarkhaja.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <commons.lang.version>2.6</commons.lang.version>
     <springframework-version>3.2.0</springframework-version>
     <osgi.over.slf4j.version>1.7.7</osgi.over.slf4j.version>
-    <eigenbase.xom.version>1.3.4</eigenbase.xom.version>
+    <eigenbase.xom.version>1.3.5</eigenbase.xom.version>
     <karaf.features.version>3.0.3</karaf.features.version>
     <commons.logging.version>1.1.3</commons.logging.version>
     <org.ops4j.pax.web.version>3.1.4</org.ops4j.pax.web.version>


### PR DESCRIPTION
 - eigenbase-xom dependency is updated to 1.3.5

@mbatchelor, @pamval, @lucboudreau, could you please take a look?   