### PR TITLE
[PPP-3554] Use of vulnerable component com.thoughtworks.xstream v1.4.…

### DIFF
--- a/pentaho-karaf-assembly/pom.xml
+++ b/pentaho-karaf-assembly/pom.xml
@@ -147,8 +147,6 @@
                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard</descriptor>
                 <descriptor>mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features</descriptor>
                 <descriptor>mvn:org.pentaho/pdi-marketplace/${project.version}/xml/features</descriptor>
               </descriptors>
@@ -184,8 +182,6 @@
                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard</descriptor>
                 <descriptor>mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features</descriptor>
               </descriptors>
               <features>
@@ -220,8 +216,6 @@
                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/server</descriptor>
-                <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features</descriptor>
                 <descriptor>mvn:org.pentaho/pentaho-marketplace/${project.version}/xml/features</descriptor>
               </descriptors>
@@ -259,8 +253,6 @@
                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard</descriptor>
                 <descriptor>mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features</descriptor>
               </descriptors>
               <features>
@@ -290,8 +282,6 @@
                 <descriptor>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard</descriptor>
                 <descriptor>mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features</descriptor>
-                <descriptor>mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features</descriptor>
                 <descriptor>mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features</descriptor>
               </descriptors>
               <features>

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-client/org.apache.karaf.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-client/org.apache.karaf.features.cfg
@@ -23,7 +23,7 @@ respectStartLvlDuringFeatureStartup=false
 #
 # Comma separated list of features repositories to register by default
 #
-featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features,mvn:org.pentaho/pdi-marketplace/${project.version}/xml/features
+featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features,mvn:org.pentaho/pdi-marketplace/${project.version}/xml/features
 
 #
 # Comma separated list of features to install at startup

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-pme/org.apache.karaf.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-pme/org.apache.karaf.features.cfg
@@ -23,7 +23,7 @@ respectStartLvlDuringFeatureStartup=false
 #
 # Comma separated list of features repositories to register by default
 #
-featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features
+featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features
 
 #
 # Comma separated list of features to install at startup

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/org.apache.karaf.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/org.apache.karaf.features.cfg
@@ -22,7 +22,7 @@ respectStartLvlDuringFeatureStartup=false
 #
 # Comma separated list of features repositories to register by default
 #
-featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/server,mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.pentaho/pentaho-marketplace/${project.version}/xml/features
+featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/enterprise/${karaf.features.version}/xml/features,mvn:org.apache.karaf.features/spring/${karaf.features.version}/xml/features,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/standard,mvn:pentaho/pentaho-karaf-features/${project.version}/xml/server,mvn:pentaho-karaf-features/pentaho-big-data-plugin-osgi/${project.version}/xml/features,mvn:org.apache.cxf.karaf/apache-cxf/${cxf.karaf.version}/xml/features,mvn:org.pentaho/pentaho-marketplace/${project.version}/xml/features
 
 #
 # Comma separated list of features to install at startup

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -249,28 +249,152 @@
     <bundle dependency="true" start-level="30">mvn:org.ow2.asm/asm-all/5.0.2</bundle>
     <bundle start-level="30">mvn:org.eclipse.jetty.aggregate/jetty-all-server/8.1.15.v20140411</bundle>
   </feature>
-    <!-- Overriding activemq to exclude xtreaam 1.4.7 version  -->
-  <feature name="activemq" description="ActiveMQ broker libraries" version="5.12.0" resolver="(obr)" start-level="50">
-        <feature>http</feature>
-        <feature version="5.10.0">activemq-client</feature>
-        <bundle>mvn:org.apache.activemq/activemq-karaf/5.10.0</bundle>
-        <bundle dependency="true">mvn:org.apache.xbean/xbean-spring/3.16</bundle>
-        <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
-        <bundle dependency='true'>mvn:commons-lang/commons-lang/2.6</bundle>
-        <bundle dependency="true">mvn:commons-codec/commons-codec/1.4</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.velocity/1.7_6</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/1.9.1_1</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/1.9.0</bundle>
-        <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_5</bundle>
-        <bundle dependency="true">mvn:joda-time/joda-time/1.6.2</bundle>
-        <!--<bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.7_1</bundle>-->
-        <bundle dependency="true">mvn:org.apache.aries.transaction/org.apache.aries.transaction.manager/1.0.0</bundle>
-        <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-j2ee-connector_1.5_spec/2.0.0</bundle>
-        <bundle dependency="true">mvn:org.apache.aries/org.apache.aries.util/1.0.0</bundle>
-        <bundle dependency="true">mvn:org.apache.activemq/activeio-core/3.1.4</bundle>
-        <bundle dependency="true">mvn:org.codehaus.jettison/jettison/1.3.5</bundle>
-        <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/1.9.12</bundle>
-        <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.12</bundle>
-        <bundle dependency="true">mvn:org.scala-lang/scala-library/2.11.0</bundle>
+
+
+  <!-- In order to replace xstream 1.4.7 version with 1.4.9, we must not include activemq-karaf descriptor.
+    Hence, we have to copy the features we're depending on to our descriptor. -->
+  <!-- Features copied from mvn:org.apache.activemq/activemq-karaf/${activemq.karaf.version}/xml/features
+    to replace xstream 1.4.7 version with 1.4.9 -->
+  <feature name="activemq" description="ActiveMQ broker libraries" version="5.10.0" resolver="(obr)" start-level="50">
+    <feature>http</feature>
+    <feature version="5.10.0">activemq-client</feature>
+    <bundle>mvn:org.apache.activemq/activemq-karaf/5.10.0</bundle>
+    <bundle dependency="true">mvn:org.apache.xbean/xbean-spring/3.16</bundle>
+    <bundle dependency="true">mvn:commons-collections/commons-collections/3.2.2</bundle>
+    <bundle dependency='true'>mvn:commons-lang/commons-lang/2.6</bundle>
+    <bundle dependency="true">mvn:commons-codec/commons-codec/1.4</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.velocity/1.7_6</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jasypt/1.9.1_1</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/1.9.0</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_5</bundle>
+    <bundle dependency="true">mvn:joda-time/joda-time/1.6.2</bundle>
+    <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.9_1</bundle>
+    <bundle dependency="true">mvn:org.apache.aries.transaction/org.apache.aries.transaction.manager/1.0.0</bundle>
+    <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-j2ee-connector_1.5_spec/2.0.0</bundle>
+    <bundle dependency="true">mvn:org.apache.aries/org.apache.aries.util/1.0.0</bundle>
+    <bundle dependency="true">mvn:org.apache.activemq/activeio-core/3.1.4</bundle>
+    <bundle dependency="true">mvn:org.codehaus.jettison/jettison/1.3.5</bundle>
+    <bundle dependency="true">mvn:org.codehaus.jackson/jackson-core-asl/1.9.12</bundle>
+    <bundle dependency="true">mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.12</bundle>
+    <bundle dependency="true">mvn:org.scala-lang/scala-library/2.11.0</bundle>
   </feature>
+  <feature name="activemq-client" description="ActiveMQ client libraries" version="5.10.0" resolver="(obr)" start-level="50">
+    <feature version="[3.1,4)">spring</feature>
+    <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-annotation_1.0_spec/1.1.1</bundle>
+    <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+    <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+    <bundle dependency="true">mvn:org.apache.geronimo.specs/geronimo-j2ee-management_1.1_spec/1.0.1</bundle>
+    <bundle dependency="true">mvn:org.jvnet.jaxb2_commons/jaxb2-basics-runtime/0.6.4</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.1.1_2</bundle>
+    <bundle dependency="false">mvn:commons-pool/commons-pool/1.6</bundle>
+    <bundle dependency="false">mvn:commons-net/commons-net/3.3</bundle>
+    <bundle dependency='true'>mvn:org.apache.zookeeper/zookeeper/3.4.5</bundle>
+    <bundle dependency="false">mvn:org.apache.xbean/xbean-spring/3.16</bundle>
+    <bundle>mvn:org.apache.activemq/activemq-osgi/5.10.0</bundle>
+  </feature>
+  <feature name="activemq-camel" version="5.10.0" resolver="(obr)" start-level="50">
+    <feature version="5.10.0">activemq-client</feature>
+    <bundle>mvn:org.apache.activemq/activemq-camel/5.10.0</bundle>
+    <feature version="[2.12,3)">camel-jms</feature>
+    <feature version="[2.12,3)">camel</feature>
+  </feature>
+
+
+  <!-- In order to replace xstream 1.4.7 version with 1.4.9, we must not include apache-camel descriptor.
+    Hence, we have to copy the features we're depending on to our descriptor. -->
+  <!-- Features copied from mvn:org.apache.camel.karaf/apache-camel/${camel.karaf.version}/xml/features
+    to replace xstream 1.4.7 version with 1.4.9-->
+  <feature name='camel-xstream' version='2.14.3' resolver='(obr)' start-level='50'>
+    <bundle dependency='true'>mvn:org.codehaus.jettison/jettison/1.3.5</bundle>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_7</bundle>
+    <bundle dependency='true'>mvn:joda-time/joda-time/1.6.2</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jdom/1.1_4</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.dom4j/1.6.1_5</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.kxml2/2.3.0_2</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.9_1</bundle>
+    <bundle>mvn:org.apache.camel/camel-xstream/2.16.3</bundle>
+  </feature>
+  <feature name='camel-salesforce' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature>jetty</feature>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle dependency='true'>mvn:org.codehaus.jackson/jackson-mapper-asl/1.9.12</bundle>
+    <bundle dependency='true'>mvn:org.codehaus.jackson/jackson-core-asl/1.9.12</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.9_1</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/1.1.4c_7</bundle>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-servlet_3.0_spec/1.0</bundle>
+    <bundle dependency='true'>mvn:org.cometd.java/cometd-java-client/2.4.3</bundle>
+    <bundle dependency='true'>mvn:org.cometd.java/bayeux-api/2.4.3</bundle>
+    <bundle dependency='true'>mvn:org.cometd.java/cometd-java-common/2.4.3</bundle>
+    <bundle dependency='true'>mvn:joda-time/joda-time/2.5</bundle>
+    <bundle>mvn:org.apache.camel/camel-salesforce/2.14.3</bundle>
+  </feature>
+  <feature name='camel-optaplanner' version='2.14.3' resolver='(obr)' start-level='50'>
+    <details>The camel-optaplanner feature can only run on a SUN JVM. You need to add the package com.sun.tools.xjc to the java platform packages in the etc/jre.properties file.</details>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle dependency='true'>mvn:com.google.guava/guava/17.0</bundle>
+    <bundle dependency='true'>mvn:org.apache.commons/commons-math3/3.3</bundle>
+    <bundle dependency='true'>mvn:commons-lang/commons-lang/2.6</bundle>
+    <bundle dependency='true'>mvn:commons-io/commons-io/1.4</bundle>
+    <bundle dependency='true'>mvn:commons-collections/commons-collections/3.2.2</bundle>
+    <bundle dependency='true'>mvn:org.optaplanner/optaplanner-core/6.1.0.Final</bundle>
+    <bundle dependency='true'>mvn:org.kie/kie-api/6.1.0.Final</bundle>
+    <bundle dependency='true'>mvn:org.kie/kie-internal/6.1.0.Final</bundle>
+    <bundle dependency='true'>mvn:org.drools/drools-core/6.1.0.Final</bundle>
+    <bundle dependency='true'>mvn:org.drools/drools-compiler/6.1.0.Final</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/2.2.1.1_2</bundle>
+    <!-- the ecj bundle on the central is malformed as both 'META-INF' and 'META-INF/MANIFEST.MF' entries are NOT the first 2 entries inside the jar when -->
+    <!-- one verifies this through 'jar -tf ecj-4.2.2.jar'. one possible workaround for this is to make use of the wrap protocol. -->
+    <bundle dependency='true'>wrap:mvn:org.eclipse.jdt.core.compiler/ecj/4.2.2</bundle>
+    <bundle dependency='true'>mvn:org.mvel/mvel2/2.2.1.Final</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/1.4.9_1</bundle>
+    <bundle dependency='true'>mvn:com.google.protobuf/protobuf-java/2.5.0</bundle>
+    <bundle dependency='true'>mvn:com.google.guava/guava/17.0</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
+    <bundle>mvn:org.apache.camel/camel-optaplanner/2.14.3</bundle>
+  </feature>
+  <feature name='camel-jms' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature version='[3.2,4)'>spring</feature>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+    <bundle dependency='true'>mvn:commons-pool/commons-pool/1.6</bundle>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+    <feature version='[3.2,4)'>spring-jms</feature>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle>mvn:org.apache.camel/camel-jms/2.14.3</bundle>
+  </feature>
+  <feature name='camel-stream' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle>mvn:org.apache.camel/camel-stream/2.14.3</bundle>
+  </feature>
+  <feature name='camel' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature version='2.14.3'>camel-core</feature>
+    <feature version='2.14.3'>camel-spring</feature>
+    <feature version='2.14.3'>camel-blueprint</feature>
+  </feature>
+  <feature name='camel-core' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature version='2.2.0'>xml-specs-api</feature>
+    <bundle>mvn:org.apache.camel/camel-core/2.14.3</bundle>
+    <bundle>mvn:org.apache.camel.karaf/camel-karaf-commands/2.14.3</bundle>
+  </feature>
+  <feature name='camel-spring' version='2.14.3' resolver='(obr)' start-level='50'>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+    <feature version='[3.2,4)'>spring</feature>
+    <feature version='[1.2,2)'>spring-dm</feature>
+    <feature version='[3.2,4)'>spring-tx</feature>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle>mvn:org.apache.camel/camel-spring/2.14.3</bundle>
+  </feature>
+  <feature name='camel-blueprint' version='2.14.3' resolver='(obr)' start-level='50'>
+    <feature version='2.14.3'>camel-core</feature>
+    <bundle>mvn:org.apache.camel/camel-blueprint/2.14.3</bundle>
+  </feature>
+  <feature name='xml-specs-api' version='2.2.0' resolver='(obr)' start-level='10'>
+    <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.2.0</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.stax-api-1.0/2.2.0</bundle>
+    <bundle dependency='true'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/2.2.0</bundle>
+    <bundle>mvn:org.codehaus.woodstox/stax2-api/3.1.4</bundle>
+    <bundle>mvn:org.codehaus.woodstox/woodstox-core-asl/4.2.1</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/2.2.1.1_2</bundle>
+  </feature>
+
 </features>


### PR DESCRIPTION
…2/1.4.7 in karaf bundles

 - removed activemq-karaf and apache-camel descriptors from karaf-maven-plugin configuration
 - copied features we are depending on from removed descriptors to ours