### PR TITLE
PDI-15515 - Removing legacy ESAPI encoder from projects

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -121,6 +121,6 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.json.simple;version\="1.1.0", \
  mondrian.*, \
  olap4j.*, \
- org.owasp.esapi.*
+ org.owasp.encoder.*
 karaf.shutdown.port=-1
 org.osgi.framework.storage.clean=none


### PR DESCRIPTION
Removing legacy ESAPI encoder from projects and replacing it by org.owasp.encoder