### PR TITLE
[6.1.0.9][SP-2974][BACKLOG-10830] Remove external angular-translate from marketplace

### DIFF
--- a/pentaho-karaf-assembly/pom.xml
+++ b/pentaho-karaf-assembly/pom.xml
@@ -60,7 +60,6 @@
 	<osgi.over.slf4j.version>1.7.7</osgi.over.slf4j.version>
 	<!-- org.webjars -->
 	<angular.sanitize.version>1.5.8</angular.sanitize.version>
-  <angular-translate.version>2.12.1</angular-translate.version>
 	<underscorejs.version>1.7.0</underscorejs.version>
   </properties>
   <dependencies>

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -97,7 +97,6 @@
     <!-- START client side dependencies -->
     <bundle>mvn:pentaho/pentaho-angular-bundle/${dependency.pentaho-osgi-bundles.revision}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-sanitize/${angular.sanitize.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-translate/${angular-translate.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars/underscorejs/${underscorejs.version}</bundle>
     <bundle>pentaho-platform-plugin-mvn:pentaho/common-ui/${dependency.common-ui.revision}/zip</bundle>
     <!-- END -->
@@ -122,7 +121,6 @@
     <!-- START client side dependencies -->
     <bundle>mvn:pentaho/pentaho-angular-bundle/${dependency.pentaho-osgi-bundles.revision}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-sanitize/${angular.sanitize.version}</bundle>
-    <bundle>pentaho-webjars:mvn:org.webjars.bower/angular-translate/${angular-translate.version}</bundle>
     <bundle>pentaho-webjars:mvn:org.webjars/underscorejs/${underscorejs.version}</bundle>
     <!-- END -->
 

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
 	<osgi.over.slf4j.version>1.7.7</osgi.over.slf4j.version>
 	<!-- org.webjars -->
 	<angular.sanitize.version>1.5.8</angular.sanitize.version>
-    <angular-translate.version>2.12.1</angular-translate.version>
 	<underscorejs.version>1.7.0</underscorejs.version>
 	
 	<springframework-version>3.2.0</springframework-version>


### PR DESCRIPTION
Related with https://github.com/pentaho/marketplace/pull/127.

@pamval please review.