### PR TITLE
Revert "[BACKLOG-13473] -- added pentaho-geo feature"

### DIFF
--- a/pentaho-karaf-features/pom.xml
+++ b/pentaho-karaf-features/pom.xml
@@ -16,7 +16,6 @@
     <obf.jar.designator></obf.jar.designator>
     <mongolap.unobfuscated.designator>-plain</mongolap.unobfuscated.designator>
     <dependency.mondrian4.revision>4.7-SNAPSHOT</dependency.mondrian4.revision>
-    <dependency.flexjson.version>3.3</dependency.flexjson.version>
   </properties>
   <build>
     <plugins>

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -29,12 +29,6 @@
     <bundle>pentaho-platform-plugin-mvn:pentaho/paz-plugin-ce/${project.version}/zip</bundle>
   </feature>
 
-  <feature name="pentaho-geo" version="1.0">
-    <bundle>mvn:net.sf.flexjson/flexjson/${dependency.flexjson.version}</bundle>
-    <bundle>mvn:pentaho/pentaho-geo-agile-bi/${project.version}</bundle>
-    <bundle>mvn:pentaho/dataservice-geo-impl/${project.version}</bundle>
-  </feature>
-
   <feature name="mongolap" version="1.0">
     <feature>pentaho-server</feature>
     <bundle>mvn:org.pentaho/mondrian/${dependency.mondrian4.revision}</bundle>


### PR DESCRIPTION
@pentaho/millenniumfalcon @nantunes please review

Removing manually defined feature for pentaho geo as the feature is now automatically handled by the geo plugin. Geo is now included in PDI through DET.

Related PRs:
https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/96
https://github.com/pentaho/pentaho-det-ee/pull/360
https://github.com/pentaho/pentaho-platform-plugin-geo/pull/137

This reverts commit a3cecef2ded7eaa34b626c7de0bcf08582b173e7.

