### PR TITLE
[BACKLOG-15780] Remove commmons-beanutils from custom.properties

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -62,7 +62,6 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.beanutils; version=1.8, \
  org.apache.commons.vfs2.*; version=2.1, \
  org.apache.html.dom; version\="2.11.0", \
  org.apache.karaf.branding, \


### PR DESCRIPTION
**org.apache.commons.beanutils** is not required to be imported in **custom.properties** file, each project that requires this dependency should call it