### PR TITLE
[BACKLOG-15171] AEL proxy-user. For UserGroupInformation class.

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -26,6 +26,7 @@ karaf.systemBundlesStartLevel=50
 
 org.osgi.framework.system.packages.extra= \
  org.apache.spark.*, \
+ org.apache.hadoop.security.* \
  scala.*;version="2.11.0", \
  com.pentaho.commons.dsc, \
  com.pentaho.commons.dsc.params, \


### PR DESCRIPTION
@CodeOnCoffee add packages needed for UserGroupInformation class.  

Belongs with other PR: https://github.com/pentaho/pentaho-ee/pull/157