### PR TITLE
[CLEANUP] remove ael-security feature from karaf-assembly

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/client-extras/etc-spoon/org.pentaho.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/client-extras/etc-spoon/org.pentaho.features.cfg
@@ -1,2 +1,2 @@
 # Additional Features to be installed at startup
-runtimeFeatures=pentaho-client,pentaho-metaverse,pdi-dataservice,pdi-data-refinery,pdi-marketplace,community-edition,http,war,kar,cxf,pdi-platform,pentaho-spoon,repositories-plugin,pdi-engine-configuration-ui,ael-security
+runtimeFeatures=pentaho-client,pentaho-metaverse,pdi-dataservice,pdi-data-refinery,pdi-marketplace,community-edition,http,war,kar,cxf,pdi-platform,pentaho-spoon,repositories-plugin,pdi-engine-configuration-ui


### PR DESCRIPTION
@pentaho/rogueone Remove ael-security from karaf-assembly so jaas won't be enabled by default. Please review.