### PR TITLE
[BACKLOG-16167]-Spoon hangs on after adding hadoop cluster (The Kettle Karaf Lifecycle Listener failed to execute properly after waiting for 100 seconds)

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -110,7 +110,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.platform.servicecoordination.impl;version\="${pentaho-osgi-bundles.osgi.version}", \
  org.owasp.encoder.*, \
  io.reactivex.*;version\="2.0.4", \
- org.pentaho.di.engine.*;version="${kettle.version}", \
+ org.pentaho.di.engine.*;version="${kettle.osgi.version}", \
  org.reactivestreams.*;version="1.0.0"
 
 karaf.shutdown.port=-1

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -125,7 +125,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  olap4j.*, \
  org.owasp.encoder.*, \
  io.reactivex.*;version\="2.0.4", \
- org.pentaho.di.engine.*;version="${kettle.version}", \
+ org.pentaho.di.engine.*;version="${kettle.osgi.version}", \
  org.reactivestreams.*;version="1.0.0"
 karaf.shutdown.port=-1
 org.osgi.framework.storage.clean=none

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
     <pentaho-osgi-bundles.version>8.0-SNAPSHOT</pentaho-osgi-bundles.version>
     <pentaho-osgi-bundles.osgi.version>8.0.0.SNAPSHOT</pentaho-osgi-bundles.osgi.version>
     <kettle.version>8.0-SNAPSHOT</kettle.version>
+    <kettle.osgi.version>8.0.0.SNAPSHOT</kettle.osgi.version>
     <eigenbase.xom.version>1.3.5</eigenbase.xom.version>
     <osgi.over.slf4j.version>1.7.7</osgi.over.slf4j.version>
     <springframework-version>3.2.0</springframework-version>


### PR DESCRIPTION
core org.pentaho.di.engine.*;version="8.0-QAT-83", can't be loaded
fix with kettle.version for karaf, adding separate property kettle.osgi.version
karaf can't parse version with symbols "-"
the format should be "MAJOR.MINOR.MICRO.QUALIFIER"

the fix is analog of https://github.com/pentaho/pentaho-karaf-assembly/commit/733c9fb3746c99c1595e25b0c414f28051232254#diff-600376dffeb79835ede4a0b285078036R55

also according to slack discussion possible solution could be 
"we probably need to reach out to the build team as well. We want the maven versions to be paired with the osgi versions and the build team has all that magic on the version merger and updating version for new branches etc. We should check how the new osgi version properties fit in that process"