### PR TITLE
[BACKLOG-16246] - Remove client-extras from karaf prd assembly

### DIFF
--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-prd-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-prd-assembly.xml
@@ -72,16 +72,6 @@
       </excludes>
     </fileSet>
     <fileSet>
-      <directory>target/classes/client-extras</directory>
-      <outputDirectory>/</outputDirectory>
-      <lineEnding>unix</lineEnding>
-      <fileMode>0644</fileMode>
-      <excludes>
-        <exclude>**/*.formatted</exclude>
-      </excludes>
-    </fileSet>
-
-    <fileSet>
       <directory>target/classes/deploy</directory>
       <outputDirectory>/deploy/</outputDirectory>
       <lineEnding>unix</lineEnding>


### PR DESCRIPTION
- Client-extras add addition etc folder for cart, kitchen, pan and spark. This is not needed in PRD