### PR TITLE
[BACKLOG-17323] Create a worker-nodes-ee OSGi plugin

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -29,6 +29,7 @@ org.osgi.framework.system.packages.extra= \
  com.pentaho.commons.dsc, \
  com.pentaho.commons.dsc.params, \
  com.pentaho.commons.dsc.tlsup.*, \
+ com.pentaho.messages.*, \
  com.sun.security.auth.module, \
  com.tinkerpop.blueprints.*, \
  javax.annotation.*;version="1.2", \
@@ -54,6 +55,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
  org.apache.commons.vfs2.*; version=2.1, \
+ org.apache.http.client.utils.*; version\="3.1", \
  org.apache.html.dom; version\="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version\="3.0.3", \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -31,6 +31,7 @@ org.osgi.framework.system.packages.extra= \
  com.pentaho.commons.dsc, \
  com.pentaho.commons.dsc.params, \
  com.pentaho.commons.dsc.tlsup.*, \
+ com.pentaho.messages.*, \
  com.sun.security.auth.module, \
  com.tinkerpop.blueprints.*, \
  mondrian.olap4j.*, \
@@ -64,6 +65,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
  org.apache.commons.vfs2.*; version=2.1, \
+ org.apache.http.client.utils.*; version\="3.1", \
  org.apache.html.dom; version\="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version\="3.0.3", \


### PR DESCRIPTION
Exporting 2 packages more through OSGi's system bundle. 
OSGi platform EE plugins that require these should not be forced to bundle them into its own feature as these 2 already exist. They merely need to be exposed to the OSGi world via our system bundle.

@pentaho/rogueone @pentaho/rebelalliance 