### PR TITLE
[PPP-3807] Use of vulnerable component camel-blueprint-2.14.3.jar CVE…

### DIFF
--- a/pentaho-karaf-assembly/pom.xml
+++ b/pentaho-karaf-assembly/pom.xml
@@ -257,7 +257,7 @@
                 <feature>management</feature>
                 <feature>kar</feature>
                 <feature>cxf</feature>
-                <feature>camel-jms</feature>
+                <feature>camel-jms/${camel.overriden.karaf.version}</feature>
                 <feature>camel</feature>
                 <feature>camel-blueprint</feature>
                 <feature>camel-stream</feature>

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -136,7 +136,7 @@
   </feature>
 
   <feature name="pentaho-camel-jms" version="1.0">
-    <feature>camel-jms</feature>
+    <feature version="${camel.overriden.karaf.version}">camel-jms</feature>
     <feature>activemq-camel</feature>
     <feature>pentaho-jms</feature>
     <bundle start-level="90">blueprint:mvn:pentaho/pentaho-blueprint-activators/${project.version}/xml/camel-jms</bundle>
@@ -329,5 +329,16 @@
     <bundle start-level="30">mvn:org.springframework.security/spring-security-web/3.1.7.RELEASE</bundle>
     <bundle start-level="30">mvn:org.springframework.security/spring-security-acl/3.1.7.RELEASE</bundle>
     <bundle start-level="30">mvn:org.springframework.security/spring-security-taglibs/3.1.7.RELEASE</bundle>
+  </feature>
+
+  <!-- Overriding camel-jms feature to force using Spring 3.2.11.RELEASE_1  -->
+  <feature name='camel-jms' version='${camel.overriden.karaf.version}' resolver='(obr)' start-level='50'>
+    <feature version='${camel.karaf.version}'>camel-core</feature>
+    <feature version='3.2.11.RELEASE_1'>spring</feature>
+    <feature version='3.2.11.RELEASE_1'>spring-jms</feature>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
+    <bundle dependency='true'>mvn:commons-pool/commons-pool/1.6</bundle>
+    <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1</bundle>
+    <bundle>mvn:org.apache.camel/camel-jms/${camel.karaf.version}</bundle>
   </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <eigenbase.resgen.version>1.3.6</eigenbase.resgen.version>
     <activemq.karaf.version>5.10.0</activemq.karaf.version>
     <camel.karaf.version>2.17.7</camel.karaf.version>
+    <camel.overriden.karaf.version>2.17.7-pentaho</camel.overriden.karaf.version>
     <olap4j.xmlaserver.version>1.2.0</olap4j.xmlaserver.version>
     <dependency.mondrian4.revision>4.8-SNAPSHOT</dependency.mondrian4.revision>
     <google.guava.version>17.0</google.guava.version>


### PR DESCRIPTION
…-2017-5643 CVE-2017-3159 CVE-2015-5348 CVE-2015-5344

 - added overriden camel-jms feature descriptor to force using spring of 3.2 version, since activemq-camel requires it