### PR TITLE
[PPP-3807] Use of vulnerable component camel-blueprint-2.14.3.jar CVE…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -84,6 +84,6 @@
   <feature name='camel-guava-eventbus' version='2.17.7-pentaho' resolver='(obr)' start-level='50'>
     <feature version='2.17.7'>camel-core</feature>
     <bundle dependency='true'>mvn:com.google.guava/guava/17.0</bundle>
-    <bundle>mvn:org.apache.camel/camel-guava-eventbus/2.17.7</bundle>
+    <bundle>mvn:pentaho/pentaho-camel-guava-eventbus/${project.version}</bundle>
   </feature>
 </features>


### PR DESCRIPTION
…-2017-5643 CVE-2017-3159 CVE-2015-5348 CVE-2015-5344

 - replaced camel-guava-eventbus bundle with ours overriden, which wraps the original one only overriding its dependencies to force using guava-17.0