### PR TITLE
[BACKLOG-18865]-add hadoop.conf package to karaf for changing spark o…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -28,6 +28,8 @@ org.osgi.framework.system.packages.extra= \
  org.apache.spark.*, \
  org.apache.kafka.*, \
  org.apache.hadoop.security.*, \
+ org.apache.hadoop.conf.*, \
+ org.apache.parquet.*, \
  scala.*;version="2.11.0", \
  com.pentaho.commons.dsc, \
  com.pentaho.commons.dsc, \


### PR DESCRIPTION
…ptions for parquet. SparkContext.hadoopConfiguration() require accessing Configuration class from hadoop, which will be loaded from spark/jars libraries using karaf system bundle.
should come together with
https://github.com/pentaho/big-data-plugin/pull/1066
pentaho/pentaho-ee#634