### PR TITLE
[BACKLOG-18961] Remove cxf from boot features so it does not pick the…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/org.apache.karaf.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/org.apache.karaf.features.cfg
@@ -27,7 +27,7 @@ featuresRepositories=mvn:org.apache.karaf.features/standard/${karaf.features.ver
 #
 # Comma separated list of features to install at startup
 #
-featuresBoot=config,management,kar,cxf,camel-jms,camel,camel-blueprint,camel-stream,pentaho-server,pentaho-metaverse,pdi-dataservice,pentaho-marketplace,community-edition,pdi-engine-configuration
+featuresBoot=config,management,kar,camel-jms,camel,camel-blueprint,camel-stream,pentaho-server,pentaho-metaverse,pdi-dataservice,pentaho-marketplace,community-edition,pdi-engine-configuration
 #
 # Defines if the boot features are started in asynchronous mode (in a dedicated thread)
 #


### PR DESCRIPTION
@pentaho/2-1b @graimundo

Changes in line with this [PR](https://github.com/pentaho/pentaho-karaf-assembly/pull/374)

Related PR: https://github.com/pentaho/marketplace/pull/134

Making sure the cxf feature version loaded is the pentaho overriden one and not the default one, otherwise it will lead to conflicts.