### PR TITLE
[BACKLOG-19243] Adding org.apache.hadoop.fs to custom.properties

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -30,6 +30,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.kafka.*, \
  org.apache.hadoop.security.*, \
  org.apache.hadoop.conf.*, \
+ org.apache.hadoop.fs, \
  org.apache.parquet.*, \
  scala.*;version="2.11.0", \
  com.pentaho.commons.dsc, \


### PR DESCRIPTION
To allow FileSystem to be used by SparkOperations in AEL.