### PR TITLE
[BACKLOG-21649] adding etc-scale folder to karaf client assembly

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/client-extras/etc-scale/org.pentaho.features.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/client-extras/etc-scale/org.pentaho.features.cfg
@@ -1,0 +1,2 @@
+# Additional features to be installed at startup
+runtimeFeatures=pentaho-client,pentaho-metaverse,pentaho-dataservice,pdi-data-refinery,pdi-marketplace,community-edition


### PR DESCRIPTION
- living alongside `etc-carte`, `etc-pan`, `etc-kitchen`, ... folders, there will now be an `etc-scale`

@pentaho/rogueone please review