### PR TITLE
[BACKLOG-21720] - Adding icu4j to the pentaho-analyzer feature

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -27,6 +27,7 @@
     <bundle>wrap:mvn:pentaho/pentaho-connections/${pentaho-connections.version}</bundle>
     <bundle>mvn:pentaho/pentaho-analyzer-xsd/${analyzer-plugin.version}</bundle>
     <bundle>pentaho-platform-plugin-mvn:pentaho/paz-plugin-ce/${analyzer-plugin.version}/zip</bundle>
+    <bundle dependency="true">mvn:com.ibm.icu/icu4j/${icu4j.version}</bundle>
   </feature>
 
   <feature name="pentaho-monitoring" version="1.0">

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <commons.io.version>2.4</commons.io.version>
     <net.sf.ehcache.version>2.8.3</net.sf.ehcache.version>
     <net.java.dev.jna.version>4.4.0</net.java.dev.jna.version>
+    <icu4j.version>54.1.1</icu4j.version>
   </properties>
 
 


### PR DESCRIPTION
This fixes the NoClassDefFoundError: com/ibm/icu/text/DateFormat posted in qat-builds channel

@pentaho/millenniumfalcon @bennychow please review