### PR TITLE
BACKLOG-21582 : Remove exclusion of activemq-osgi/5.10.0 

### DIFF
--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-client-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-client-assembly.xml
@@ -123,10 +123,6 @@
         <!-- Excluding the pentaho-karaf-overrides feature as it is only used during build time
              to copy the overriding bundles to the karaf/system folder. -->
         <exclude>org/pentaho/karaf/pentaho-karaf-overrides/**</exclude>
-
-        <!-- Add the bundles that are overridden in etc/override.properties here so that they are excluded
-             from the final karaf assembly -->
-        <exclude>org/apache/activemq/activemq-osgi/5.10.0/**</exclude>
       </excludes>
     </fileSet>
 

--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-pme-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-pme-assembly.xml
@@ -110,10 +110,6 @@
         <!-- Excluding the pentaho-karaf-overrides feature as it is only used during build time
              to copy the overriding bundles to the karaf/system folder. -->
         <exclude>org/pentaho/karaf/pentaho-karaf-overrides/**</exclude>
-
-        <!-- Add the bundles that are overridden in etc/override.properties here so that they are excluded
-            from the final karaf assembly -->
-        <exclude>org/apache/activemq/activemq-osgi/5.10.0/**</exclude>
       </excludes>
     </fileSet>
 

--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-pmr-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-pmr-assembly.xml
@@ -117,10 +117,6 @@
         <!-- Excluding the pentaho-karaf-overrides feature as it is only used during build time
              to copy the overriding bundles to the karaf/system folder. -->
         <exclude>org/pentaho/karaf/pentaho-karaf-overrides/**</exclude>
-
-        <!-- Add the bundles that are overridden in etc/override.properties here so that they are excluded
-             from the final karaf assembly -->
-        <exclude>org/apache/activemq/activemq-osgi/5.10.0/**</exclude>
       </excludes>
     </fileSet>
 

--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-prd-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-prd-assembly.xml
@@ -98,10 +98,6 @@
         <!-- Excluding the pentaho-karaf-overrides feature as it is only used during build time
              to copy the overriding bundles to the karaf/system folder. -->
         <exclude>org/pentaho/karaf/pentaho-karaf-overrides/**</exclude>
-
-        <!-- Add the bundles that are overridden in etc/override.properties here so that they are excluded
-             from the final karaf assembly -->
-        <exclude>org/apache/activemq/activemq-osgi/5.10.0/**</exclude>
       </excludes>
     </fileSet>
 

--- a/pentaho-karaf-assembly/src/main/descriptors/pentaho-server-assembly.xml
+++ b/pentaho-karaf-assembly/src/main/descriptors/pentaho-server-assembly.xml
@@ -122,10 +122,6 @@
         <!-- Excluding the pentaho-karaf-overrides feature as it is only used during build time
              to copy the overriding bundles to the karaf/system folder. -->
         <exclude>org/pentaho/karaf/pentaho-karaf-overrides/**</exclude>
-
-        <!-- Add the bundles that are overridden in etc/override.properties here so that they are excluded
-             from the final karaf assembly -->
-        <exclude>org/apache/activemq/activemq-osgi/5.10.0/**</exclude>
       </excludes>
     </fileSet>
 


### PR DESCRIPTION
Remove exclusion of activemq-osgi/5.10.0 karaf overrides has a bug that requires overriden bundles to be present to load the manifest to inspect bundle information.
Not having the overriden bundle was preventing activemq bundles , features from installing

Testing: The 5.10.0 activemq-osgi bundle gets shipped with the ee-karaf-assembly. Verified that the zip has both versions. Unzipped system/org/apache/activemq of ee version and restarted server and made sure that pentaho-camel-jms and activemq features are installed and no exception is thrown in pentaho.log 

Merge along with related PR :  https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/190

Note: Make sure any verification testing is done on a system that does not have maven installed

@pentaho/rogueone @graimundo 