### PR TITLE
Revert "[PPP-3876]-Use of vulnerable component spring-security-core 4.1.9 cve-2017-4995"

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -94,7 +94,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.xul.swt.tab, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.2.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.3.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -110,7 +110,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.pentaho.platform.*, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.2.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.3.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \


### PR DESCRIPTION
Reverts pentaho/pentaho-karaf-assembly#395

- Reverted as per the decisions made ( and captured ) at https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=336291#comment-336291

Part of a bulk-revert, comprised of the PR list captured at https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=321593#comment-321593:

@pentaho/rogueone @pamval @dkincade @mbatchelor @mdamour1976 @graimundo 

 ~Please **hold off merging** until we have triggered a "Revert PR" for all PRs outlined in https://jira.pentaho.com/browse/PPP-3876?focusedCommentId=321593#comment-321593~ ✅ 

## Issued Revert PRs

* https://github.com/pentaho/pentaho-engineering-samples/pull/61
* https://github.com/pentaho/marketplace/pull/147
* https://github.com/pentaho/data-access/pull/999
* https://github.com/pentaho/pentaho-kettle/pull/5176
* https://github.com/pentaho/pentaho-platform-ee/pull/1256
* https://github.com/pentaho/pentaho-karaf-assembly/pull/435
* https://github.com/pentaho/pdi-ee-plugin/pull/354
* https://github.com/pentaho/pentaho-platform/pull/4097
* https://github.com/pentaho/pentaho-osgi-bundles/pull/263
* https://github.com/pentaho/pentaho-reporting/pull/1123
* https://github.com/pentaho/pentaho-reportdesigner-ee/pull/104
* https://github.com/pentaho/pentaho-metadata-editor/pull/121
* https://github.com/pentaho/pentaho-metadata-editor-ee/pull/32


**Notes**

* https://github.com/pentaho/pentaho-ee/pull/860 not needing revert; a subsequent refactor of this project's assembly process has removed the impacted file
* https://github.com/pentaho/pdi-agile-bi-plugin/pull/87 not needing revert: as this project was retired / deprecated on Feb.14 , therefore not holding any files any longer
** https://github.com/pentaho/pdi-agile-bi-plugin/commit/67662b0a6c5f4161a290467e6f6d5f0d0f805908  