### PR TITLE
[BACKLOG-22526] vulnerable component spring-security: upgrade from 4.…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -95,7 +95,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.xul.swt.tab, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.1.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.5.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -110,7 +110,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.pentaho.platform.*, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.1.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.5.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \


### PR DESCRIPTION
…1.3 to 4.1.5

**Minor patch upgrade**: from 4.1.3 to 4.1.5

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs
- https://github.com/pentaho/marketplace/pull/148
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/33
- https://github.com/pentaho/pentaho-metadata-editor/pull/122
- https://github.com/pentaho/pentaho-kettle/pull/5203
- https://github.com/pentaho/pentaho-platform/pull/4100
- https://github.com/pentaho/pentaho-platform-ee/pull/1257
- https://github.com/pentaho/pentaho-karaf-assembly/pull/437
- https://github.com/pentaho/pdi-ee-plugin/pull/356
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/105
- https://github.com/pentaho/pentaho-reporting/pull/1127
- https://github.com/pentaho/pentaho-osgi-bundles/pull/264