### PR TITLE
[BACKLOG-22721] Fix the javax.jms.ConnectionFactory dependency missin…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-server.xml
@@ -90,6 +90,7 @@
         <feature version="[4.1.9.RELEASE_1,4.2)">spring-tx</feature>
         <bundle start-level="10">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
         <bundle start-level="10">wrap:mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1$overwrite=merge&amp;Import-Package=javax.jms;version="[1.1,1.1]",javax.transaction.xa&amp;Bundle-Version=1.1.2</bundle>
+        <bundle start-level="10">mvn:javax.jms/jms/${javax.jms.version}</bundle>
         <bundle start-level="30">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.spring-jms/4.1.9.RELEASE_1</bundle>
     </feature>
     <feature name="spring-test" version="4.1.9.RELEASE_1" description="Spring 4.1.x Test support" resolver="(obr)">

--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -327,6 +327,7 @@
     <bundle dependency='true'>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
     <bundle dependency='true'>mvn:commons-pool/commons-pool/1.6</bundle>
     <bundle dependency='true'>wrap:mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/1.1.1$overwrite=merge&amp;Import-Package=javax.jms;version="[1.1,1.1]",javax.transaction.xa&amp;Bundle-Version=1.1.2</bundle>
+    <bundle dependency='true'>mvn:javax.jms/jms/${javax.jms.version}</bundle>
     <bundle>mvn:org.apache.camel/camel-jms/${camel.karaf.version}</bundle>
   </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <net.sf.ehcache.version>2.8.3</net.sf.ehcache.version>
     <net.java.dev.jna.version>4.4.0</net.java.dev.jna.version>
     <icu4j.version>54.1.1</icu4j.version>
+    <javax.jms.version>1.1</javax.jms.version>
   </properties>
 
 


### PR DESCRIPTION
…g after server start, caused by removing the pentaho-streaming-feature feature (1d41a2c9a8a200c29c5054329ae082bac58fbd28)