### PR TITLE
[PDI-17441] Feature: Add support for ADL as an Hadoop FS

### DIFF
--- a/pentaho-osgi-config/src/main/resources/pentaho.big.data.impl.cluster.cfg
+++ b/pentaho-osgi-config/src/main/resources/pentaho.big.data.impl.cluster.cfg
@@ -2,3 +2,5 @@
 named.cluster.dfs.scheme.hdfs=HDFS
 named.cluster.dfs.scheme.maprfs=MapR
 named.cluster.dfs.scheme.wasb=WASB 
+named.cluster.dfs.scheme.wasbs=WASBS 
+named.cluster.dfs.scheme.adl=ADL


### PR DESCRIPTION
There is support for the adl scheme in current hadoop. This PR adds support for Azure DataLake storage in PDI. This is part of PRs against the `big-data-shims`, `pentaho-karaf-assembly`, and `pentaho-big-data-plugins` repositories.