### PR TITLE
[BACKLOG-25015] Meta-inject - Move step to Kettle plugin system

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -89,7 +89,6 @@
     <feature>pentaho-base</feature>
     <bundle>mvn:pentaho/pentaho-mongo-utils/${pentaho-mongo-utils.version}</bundle>
     <bundle>wrap:mvn:pentaho/pentaho-mongodb-plugin/${pentaho-mongodb-plugin.version}</bundle>
-    <bundle>wrap:mvn:org.pentaho.di.plugins/meta-inject-plugin/${pdi.version}</bundle>
     <bundle>mvn:org.mongodb/mongo-java-driver/${mongo.java.driver.version}</bundle>
     <bundle>mvn:pentaho/pdi-osgi-bridge-activator/${pdi-osgi-bridge.version}</bundle>
    <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>


### PR DESCRIPTION
- `ETL Metadata injection` was converted from its OSGi from, to the "classic" PDI plugin form

To be merged alongside https://github.com/pentaho/pentaho-kettle/pull/5693 

@pentaho/rogueone @kurtwalker @mdamour1976 @hbfernandes @tmcsantos please process