### PR TITLE
[BACKLOG-23122] Karaf is going out to Nexus on startup to load Karaf …

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/org.ops4j.pax.url.mvn.cfg
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/org.ops4j.pax.url.mvn.cfg
@@ -43,7 +43,7 @@
 # above, or defaulted to:
 #     System.getProperty( "user.home" ) + "/.m2/repository"
 #
-#org.ops4j.pax.url.mvn.localRepository=
+org.ops4j.pax.url.mvn.localRepository=${karaf.home}/system
 
 #
 # Default this to false. It's just weird to use undocumented repos


### PR DESCRIPTION
…features if it can't find them locally

If not set, the value of this `org.ops4j.pax.url.mvn.localRepository` property would default to `System.getProperty( "user.home" ) + "/.m2/repository"`

Repro path outlined @ https://jira.pentaho.com/browse/BACKLOG-23122?focusedCommentId=349065#comment-349065

@pentaho/rogueone 