### PR TITLE
Revert "[BACKLOG-25015] Meta-inject - Move step to Kettle plugin system"

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -89,6 +89,7 @@
     <feature>pentaho-base</feature>
     <bundle>mvn:pentaho/pentaho-mongo-utils/${pentaho-mongo-utils.version}</bundle>
     <bundle>wrap:mvn:pentaho/pentaho-mongodb-plugin/${pentaho-mongodb-plugin.version}</bundle>
+    <bundle>wrap:mvn:org.pentaho.di.plugins/meta-inject-plugin/${pdi.version}</bundle>
     <bundle>mvn:org.mongodb/mongo-java-driver/${mongo.java.driver.version}</bundle>
     <bundle>mvn:pentaho/pdi-osgi-bridge-activator/${pdi-osgi-bridge.version}</bundle>
    <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>


### PR DESCRIPTION
Reverts pentaho/pentaho-karaf-assembly#472

The metadata-injection de-OSGification process, while working fine on Spoon, is *not* working on AEL

In light of that - and given that there is no clear strategy yet on how non-OSGi kettle plugins ( that live outside kettle-engine ) can work on AEL - it’s safer to revert the changes done, and keep metadata-injection OSGified for the time being.

@pentaho/rogueone @kurtwalker @mdamour1976 @tmcsantos @hbfernandes 