### PR TITLE
[BACKLOG-24699] Fix Spoon CE start up error of missing pentaho-requirejs-osgi-manager

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -16,6 +16,7 @@
  -->
 
 <features name="pentaho-karaf-features-standard" xmlns="http://karaf.apache.org/xmlns/features/v1.2.1">
+  <repository>mvn:org.pentaho/pentaho-requirejs-osgi-manager/${project.version}/xml/features</repository>
   <repository>mvn:org.pentaho.webpackage/pentaho-webpackage/${project.version}/xml/features</repository>
 
   <repository>mvn:pentaho/pentaho-dataservice/${project.version}/xml/features</repository>


### PR DESCRIPTION
@pentaho/millenniumfalcon please review. @jgminder I just cherry-picked your proposed fix.