### PR TITLE
[BACKLOG-22526] Use of vulnerable component spring-security 4.1.3 CVE…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -95,7 +95,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.xul.swt.tab, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.1.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.5.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -110,7 +110,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.pentaho.platform.*, \
  org.slf4j.*; version\="1.7.7", \
  org.springframework.dao; version\="4.3.2.RELEASE", \
- org.springframework.security.*; version\="4.1.3.RELEASE", \
+ org.springframework.security.*; version\="4.1.5.RELEASE", \
  org.w3c.dom, \
  org.w3c.dom.ls, \
  org.w3c.dom.xpath, \


### PR DESCRIPTION
…-2018-1199

**Minor patch upgrade**: from `4.1.3 RELEASE` to `4.1.5 RELEASE`

@pentaho/rogueone
CC'ing @pamval @dkincade @mbatchelor @mdamour1976 @graimundo

~Please **hold off** merging until we have triggered a PR for all necessary projects~ ✅ 

List of PRs:
- https://github.com/pentaho/pentaho-platform/pull/4229
- https://github.com/pentaho/pentaho-osgi-bundles/pull/288
- https://github.com/pentaho/pentaho-platform-ee/pull/1276
- https://github.com/pentaho/pentaho-kettle/pull/5750
- https://github.com/pentaho/pentaho-reporting/pull/1179
- https://github.com/pentaho/pentaho-reportdesigner-ee/pull/115
- https://github.com/pentaho/pdi-ee-plugin/pull/361
- https://github.com/pentaho/pentaho-karaf-assembly/pull/478
- https://github.com/pentaho/pentaho-metadata-editor/pull/128
- https://github.com/pentaho/pentaho-metadata-editor-ee/pull/38
- https://github.com/pentaho/marketplace/pull/152