### PR TITLE
[BACKLOG-25480] Remove duplicate code by switching it to use commons/…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -86,7 +86,7 @@
     <bundle>mvn:pentaho/pentaho-camel-guava-eventbus/${project.version}</bundle>
   </feature>
 
-  <feature name='pentaho-foundry-commons' version="${project.version}">
+  <feature name='pentaho-commons-ee' version="1.0">
     <bundle>wrap:mvn:com.jayway.jsonpath/json-path/${json-path.version}</bundle>
     <bundle>wrap:mvn:com.hitachivantara/pentaho-foundry-utils/${project.version}</bundle>
   </feature>


### PR DESCRIPTION
…foundry-utils classes

- fixed the failing feature version
- also renamed feature name from `pentaho-foundry-commons` to a name more aligned with the github project name ( github.com/pentaho-ee/commons ) , making it `pentaho-commons-ee`

@pentaho/rogueone @jmcrfp please review

To be merged alongside
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/203
- https://github.com/pentaho/pentaho-ee/pull/1532
