### PR TITLE
Revert [BACKLOG-25480] Remove duplicate code by switching it to use c…

### DIFF
--- a/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
+++ b/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-enterprise.xml
@@ -86,8 +86,4 @@
     <bundle>mvn:pentaho/pentaho-camel-guava-eventbus/${project.version}</bundle>
   </feature>
 
-  <feature name='pentaho-commons-ee' version="1.0">
-    <bundle>wrap:mvn:com.jayway.jsonpath/json-path/${json-path.version}</bundle>
-    <bundle>wrap:mvn:com.hitachivantara/pentaho-foundry-utils/${project.version}</bundle>
-  </feature>
 </features>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <net.java.dev.jna.version>4.4.0</net.java.dev.jna.version>
     <icu4j.version>54.1.1</icu4j.version>
     <javax.jms.version>1.1</javax.jms.version>
-    <json-path.version>2.4.0</json-path.version>
   </properties>
 
 


### PR DESCRIPTION
…ommons/foundry-utils classes

- reverting the addition of `pentaho-commons-ee` feature as to not break the QAT builds

@pentaho/rogueone @jmcrfp 

To be merged alongside https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/204