### PR TITLE
[PPP-4182] Use of vulnerable component dom4j-1.6.1.jar  CVE-2018-1000632

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -109,8 +109,8 @@ org.osgi.framework.system.packages.extra= \
  com.sun.jersey.core.header;version\="1.19.1", \
  com.sun.jersey.multipart;version\="1.19.1", \
  javax.ws.rs.*;version\="1.1.1", \
- org.dom4j.*, \
- org.dom4j, \
+ org.dom4j.*;version\="${dom4j.version}", \
+ org.dom4j;version\="${dom4j.version}", \
  org.pentaho.metadata.*, \
  org.pentaho.pms.core.*, \
  org.pentaho.pms.schema.*, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -126,8 +126,8 @@ org.apache.commons.logging.*; version\="1.1.3", \
  com.sun.jersey.core.header;version\="1.19.1", \
  com.sun.jersey.multipart;version\="1.19.1", \
  javax.ws.rs.*;version\="1.1.1", \
- org.dom4j.*, \
- org.dom4j, \
+ org.dom4j.*;version\="${dom4j.version}", \
+ org.dom4j;version\="${dom4j.version}", \
  org.pentaho.metadata.*, \
  org.pentaho.pms.core.*, \
  org.pentaho.pms.schema.*, \


### PR DESCRIPTION
This is one of a series of PRs. See https://github.com/pentaho/maven-parent-poms/pull/70 for the complete list and more details. **Do not merge until further notice!**

@graimundo 