### PR TITLE
[BACKLOG-26820] Fixing a typo in the pentaho.metaverse.cfg file

### DIFF
--- a/pentaho-osgi-config/src/main/resources/pentaho.metaverse.cfg
+++ b/pentaho-osgi-config/src/main/resources/pentaho.metaverse.cfg
@@ -33,4 +33,4 @@ lineage.generate.subgraphs=true
 # Determines whether to pull sub-transformation and sub-job graphs into the parent transformation.job graph
 # Default value: true
 #
-lineage.consolidate.graphs=true
+lineage.consolidate.subgraphs=true


### PR DESCRIPTION
This is a harmless typo and not a showstopper, since this property assumes the default value of true, but should be fixed