### PR TITLE
[PPP-4271] - Fixed Use of Vulnerable Component: xercesImpl-2.11.0 and…

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -69,7 +69,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.log4j.*; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
- org.apache.xerces.*; version\="2.12", \
+ org.apache.xerces.*; version\="${xercesImpl.version}}", \
  org.apache.xml.serialize; version\="2.11.0", \
  org.apache.xpath.domapi, \
  org.codehaus.enunciate.*, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc-server/custom.properties
@@ -69,7 +69,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.log4j.*; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
- org.apache.xerces.*; version\="2.9.1", \
+ org.apache.xerces.*; version\="2.12", \
  org.apache.xml.serialize; version\="2.11.0", \
  org.apache.xpath.domapi, \
  org.codehaus.enunciate.*, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -85,7 +85,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.apache.log4j.*; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
- org.apache.xerces.*; version\="2.12.0", \
+ org.apache.xerces.*; version\="${xercesImpl.version}", \
  org.apache.xml.serialize; version\="2.11.0", \
  org.apache.xpath.domapi, \
  org.codehaus.enunciate.*, \

--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -85,7 +85,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  org.apache.log4j.*; version\="1.2.17", \
  org.apache.wml.dom; version\="2.11.0", \
  org.apache.wml; version\="2.11.0", \
- org.apache.xerces.*; version\="2.9.1", \
+ org.apache.xerces.*; version\="2.12.0", \
  org.apache.xml.serialize; version\="2.11.0", \
  org.apache.xpath.domapi, \
  org.codehaus.enunciate.*, \


### PR DESCRIPTION
… xercesImpl-2.9.1 (CVE-2013-4002 | CVE-2012-0881 | CVE-2009-2625 | sonatype-2017-0348)

Do not merge before https://github.com/pentaho/maven-parent-poms/pull/120.
This is a series of PRs to update Apache Xerces to version 2.12.0.

@pentaho-lmartins 