### PR TITLE
[BACKLOG-27708] Table Input/Output for Hive HDP 2.6 - installation issue

### DIFF
--- a/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
+++ b/pentaho-karaf-assembly/src/main/filtered-resources/etc/custom.properties
@@ -153,6 +153,7 @@ org.apache.commons.logging.*; version\="1.1.3", \
  com.cloudera.impala.*, \
  com.cloudera.impala.jdbc41.*, \
  org.apache.calcite.sql.*, \
+ org.apache.hadoop.hive.ql.*, \
  org.mysql.jdbc.*
 karaf.shutdown.port=-1
 org.osgi.framework.storage.clean=none


### PR DESCRIPTION
This is required to access the locally install Hive connection jars we are required to use. 