### PR TITLE
[PPP-4283] Use of Vulnerable Components: commons-httpclient-3.0.1.jar…

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -65,7 +65,32 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.logging.*; version="${commons-logging.version}", \
  org.apache.commons.configuration.*; version="1.9", \
  org.apache.commons.dbcp, \
- org.apache.http.*, \
+ org.apache.http; version="${httpcore.version}", \
+ org.apache.http.annotation; version="${httpcore.version}", \
+ org.apache.http.concurrent; version="${httpcore.version}", \
+ org.apache.http.config; version="${httpcore.version}", \
+ org.apache.http.entity; version="${httpcore.version}", \
+ org.apache.http.impl; version="${httpcore.version}", \
+ org.apache.http.impl.bootstrap; version="${httpcore.version}", \
+ org.apache.http.impl.entity; version="${httpcore.version}", \
+ org.apache.http.io; version="${httpcore.version}", \
+ org.apache.http.pool; version="${httpcore.version}", \
+ org.apache.http.message; version="${httpcore.version}", \
+ org.apache.http.params; version="${httpcore.version}", \
+ org.apache.http.pool; version="${httpcore.version}", \
+ org.apache.http.protocol; version="${httpcore.version}", \
+ org.apache.http.ssl; version="${httpcore.version}", \
+ org.apache.http.util; version="${httpcore.version}", \
+ org.apache.http.auth.*; version="${httpclient.version}", \
+ org.apache.http.client.*; version="${httpclient.version}", \
+ org.apache.http.conn.*; version="${httpclient.version}", \
+ org.apache.http.cookie.*; version="${httpclient.version}", \
+ org.apache.http.impl.auth; version="${httpclient.version}", \
+ org.apache.http.impl.client; version="${httpclient.version}", \
+ org.apache.http.impl.conn; version="${httpclient.version}", \
+ org.apache.http.impl.conn.tsccm; version="${httpclient.version}", \
+ org.apache.http.impl.cookie; version="${httpclient.version}", \
+ org.apache.http.impl.execchain; version="${httpclient.version}", \
  org.apache.commons.math, \
  org.apache.commons.math.distribution, \
  org.apache.commons.pool, \
@@ -73,7 +98,6 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
  org.apache.commons.vfs2.*; version=2.2, \
- org.apache.http.client.utils.*; version="3.1", \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -49,7 +49,32 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.collections.*, \
  org.apache.commons.configuration.*; version="1.9", \
  org.apache.commons.dbcp, \
- org.apache.http.*, \
+ org.apache.http; version="${httpcore.version}", \
+ org.apache.http.annotation; version="${httpcore.version}", \
+ org.apache.http.concurrent; version="${httpcore.version}", \
+ org.apache.http.config; version="${httpcore.version}", \
+ org.apache.http.entity; version="${httpcore.version}", \
+ org.apache.http.impl; version="${httpcore.version}", \
+ org.apache.http.impl.bootstrap; version="${httpcore.version}", \
+ org.apache.http.impl.entity; version="${httpcore.version}", \
+ org.apache.http.io; version="${httpcore.version}", \
+ org.apache.http.pool; version="${httpcore.version}", \
+ org.apache.http.message; version="${httpcore.version}", \
+ org.apache.http.params; version="${httpcore.version}", \
+ org.apache.http.pool; version="${httpcore.version}", \
+ org.apache.http.protocol; version="${httpcore.version}", \
+ org.apache.http.ssl; version="${httpcore.version}", \
+ org.apache.http.util; version="${httpcore.version}", \
+ org.apache.http.auth.*; version="${httpclient.version}", \
+ org.apache.http.client.*; version="${httpclient.version}", \
+ org.apache.http.conn.*; version="${httpclient.version}", \
+ org.apache.http.cookie.*; version="${httpclient.version}", \
+ org.apache.http.impl.auth; version="${httpclient.version}", \
+ org.apache.http.impl.client; version="${httpclient.version}", \
+ org.apache.http.impl.conn; version="${httpclient.version}", \
+ org.apache.http.impl.conn.tsccm; version="${httpclient.version}", \
+ org.apache.http.impl.cookie; version="${httpclient.version}", \
+ org.apache.http.impl.execchain; version="${httpclient.version}", \
  org.apache.commons.logging; version="${commons-logging.version}", \
  org.apache.commons.logging.impl; version="${commons-logging.version}", \
  org.apache.commons.math, \
@@ -59,7 +84,6 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
  org.apache.commons.vfs2.*; version=2.2, \
- org.apache.http.client.utils.*; version="3.1", \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/features/spring/spring43/pom.xml
+++ b/features/spring/spring43/pom.xml
@@ -160,6 +160,16 @@
       <version>${portlet-api.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore-osgi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient-osgi</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/features/spring/spring43/pom.xml
+++ b/features/spring/spring43/pom.xml
@@ -24,8 +24,6 @@
     <aopalliance.bundle.version>1.0_6</aopalliance.bundle.version>
     <javax.websocket-api.version>1.1</javax.websocket-api.version>
     <portlet-api.version>2.0</portlet-api.version>
-    <httpcore-osgi.version>4.4.6</httpcore-osgi.version>
-    <httpclient-osgi.version>4.5.2</httpclient-osgi.version>
 
     <karaf-maven-plugin.addBundlesToPrimaryFeature>false</karaf-maven-plugin.addBundlesToPrimaryFeature>
   </properties>
@@ -160,18 +158,6 @@
       <groupId>javax.portlet</groupId>
       <artifactId>portlet-api</artifactId>
       <version>${portlet-api.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore-osgi</artifactId>
-      <version>${httpcore-osgi.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient-osgi</artifactId>
-      <version>${httpclient-osgi.version}</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
… and httpclient-4.0.1.jar (sonatype-2007-0004 | CVE-2011-1498 | CVE-2012-6153 | CVE-2012-5783)

A new commit was added to redefine both HttpClient & HttpCore since they split package at custom.properties files.