### PR TITLE
[PDI-17775] Process Files step no longer supports HTTP scheme

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -100,7 +100,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version=2.2, \
+ org.apache.commons.vfs2.*; version=2.3, \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -100,7 +100,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version=2.3, \
+ org.apache.commons.vfs2.*; version="${commons-vfs2.version}", \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -94,7 +94,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version=2.2, \
+ org.apache.commons.vfs2.*; version=2.3, \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -94,7 +94,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version=2.3, \
+ org.apache.commons.vfs2.*; version="${commons-vfs2.version}", \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \


### PR DESCRIPTION
@pentaho/tatooine @pentaho-lmartins @ssamora 

* [PDI-17775] Updating karaf assembly version for commons-vfs2

This PR is a part of a series of PR to upgrade commons-vfs2 and fix VFS issues with HTTP:
- https://github.com/pentaho/apache-vfs-browser/pull/60
- https://github.com/pentaho/big-data-plugin/pull/1929
- https://github.com/webdetails/cpk/pull/85
- https://github.com/pentaho/data-access/pull/1083
- https://github.com/pentaho/maven-parent-poms/pull/185
- https://github.com/pentaho/mondrian/pull/1177
- https://github.com/pentaho/pdi-jms-plugin/pull/73
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/102
- https://github.com/pentaho/pdi-plugins-ee/pull/139
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/82
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/51
- https://github.com/pentaho/pentaho-big-data-ee/pull/426
- https://github.com/pentaho/pentaho-commons-database/pull/177
- https://github.com/pentaho/pentaho-data-mining/pull/24
- https://github.com/pentaho/pentaho-det-ee/pull/608
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/21
- https://github.com/pentaho/pentaho-karaf-assembly/pull/615
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/277
- https://github.com/pentaho/pentaho-kettle/pull/7130
- https://github.com/pentaho/pentaho-metaverse/pull/614
- https://github.com/pentaho/pentaho-osgi-bundles/pull/347
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1493
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/328
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/765
- https://github.com/pentaho/pentaho-platform/pull/4598
- https://github.com/pentaho/pentaho-reporting/pull/1305
- https://github.com/pentaho/pentaho-s3-vfs/pull/87
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/14