### PR TITLE
[ENGOPS-6477] - Updated assemblies to use new versions of wraps for p…

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -29,7 +29,7 @@
         <!-- [BACKLOG-30800] Prevent cxf to wire to the wrong javax.ws.rs version -->
         <bundle
                 originalUri="mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/${cxf.version}"
-                replacement="mvn:org.hitachivantara/cxf-rt-frontend-jaxrs-wrap/${pentaho-osgi-bundles.version}" mode="maven" />
+                replacement="mvn:org.hitachivantara/cxf-rt-frontend-jaxrs-wrap/${cxf.version}" mode="maven" />
 
         <!-- [PPP-4430] CVE-2019-12086 Use of Vulnerable Component: jackson-databind-2.9.8.jar -->
         <!-- Replace all jackson bundles installed by activemq-karaf (first three) and apache-cxf (all) -->

--- a/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
@@ -37,7 +37,7 @@ mvn\:org.fusesource.jansi/jansi/${jansi.version} = 8
 # preventing the export of packages from the logging APIs the Pentaho products use and inject from
 # the main classloader (org.apache.commons.logging, org.apache.log4j and org.slf4j).
 # mvn\:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version} = 8
-mvn\:org.hitachivantara/pax-logging-api-wrap/${project.version} = 8
+mvn\:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version} = 8
 
 mvn\:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version} = 8
 mvn\:org.apache.felix/org.apache.felix.coordinator/${felix.coordinator.version} = 9

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -31,7 +31,7 @@
         <!-- [BACKLOG-30800] Prevent cxf to wire to the wrong javax.ws.rs version -->
         <bundle
                 originalUri="mvn:org.apache.cxf/cxf-rt-frontend-jaxrs/${cxf.version}"
-                replacement="mvn:org.hitachivantara/cxf-rt-frontend-jaxrs-wrap/${pentaho-osgi-bundles.version}" mode="maven" />
+                replacement="mvn:org.hitachivantara/cxf-rt-frontend-jaxrs-wrap/${cxf.version}" mode="maven" />
 
         <!-- [PPP-4430] CVE-2019-12086 Use of Vulnerable Component: jackson-databind-2.9.8.jar -->
         <!-- Replace all jackson bundles installed by activemq-karaf (first three) and apache-cxf (all) -->

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -81,7 +81,7 @@
          because the assemblies will fail with a missing requirement from org.ops4j.pax.url.mvn of org.slf4j
          (there's no way to tell the requirement is satisfied by the system bundle).
     -->
-    <bundle dependency="true">mvn:org.hitachivantara/pax-logging-api-wrap/${project.version}</bundle>
+    <bundle dependency="true">mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}</bundle>
 
     <feature prerequisite="true">karaf-base</feature>
 


### PR DESCRIPTION
…ax-logging and cxf-rt-frontend-jaxrs. These artifacts are now being built with a scant job.