### PR TITLE
[BACKLOG-32545] Add kafka logger package for the etl-execution plugin

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -45,6 +45,7 @@ org.osgi.framework.system.packages.extra= \
  com.pentaho.commons.dsc.params, \
  com.pentaho.commons.dsc.tlsup.*, \
  com.pentaho.messages.*, \
+ com.pentaho.di.logging.kafka.*, \
  org.pentaho.hadoop.shim.*, \
  org.pentaho.hadoop.mapreduce.*, \
  com.sun.security.auth.module, \


### PR DESCRIPTION
We need the Kafka Logging Plugin packages to be available because one of its classes is used (only in the WN case) by the etl-execution-plugin.