### PR TITLE
[PPP-4461] Use of Vulnerable Component: com.fasterxml.jackson.core:ja…

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -73,7 +73,7 @@
                 <!-- Required by jackson-dataformat-yaml -->
                 <f:bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${servicemix.jaxrs-api.version}</f:bundle>
                 <f:bundle start-level="10" dependency="true">mvn:javax.annotation/javax.annotation-api/1.3.1</f:bundle>
-                <f:bundle start-level="35">mvn:org.yaml/snakeyaml/1.23</f:bundle>
+                <f:bundle start-level="35">mvn:org.yaml/snakeyaml/1.25</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</f:bundle>

--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -34,26 +34,34 @@
         <!-- [PPP-4430] CVE-2019-12086 Use of Vulnerable Component: jackson-databind-2.9.8.jar -->
         <!-- Replace all jackson bundles installed by activemq-karaf (first three) and apache-cxf (all) -->
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-core/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-core/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-databind/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-databind/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}" mode="maven" />
+
+        <!-- [PPP-4108] Use of vulnerable component jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 -->
+        <bundle
+            originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
+            replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.codehaus.jackson/jackson-mapper-asl/[1.5.0,${codehaus-jackson.version})"
+            replacement="mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus-jackson.version}" mode="maven" />
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -75,7 +75,7 @@
                 <!-- Required by jackson-dataformat-yaml -->
                 <f:bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${servicemix.jaxrs-api.version}</f:bundle>
                 <f:bundle start-level="10" dependency="true">mvn:javax.annotation/javax.annotation-api/1.3.1</f:bundle>
-                <f:bundle start-level="35">mvn:org.yaml/snakeyaml/1.23</f:bundle>
+                <f:bundle start-level="35">mvn:org.yaml/snakeyaml/1.25</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</f:bundle>

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -36,26 +36,34 @@
         <!-- [PPP-4430] CVE-2019-12086 Use of Vulnerable Component: jackson-databind-2.9.8.jar -->
         <!-- Replace all jackson bundles installed by activemq-karaf (first three) and apache-cxf (all) -->
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-core/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-core/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-databind/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-databind/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.core/jackson-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.dataformat/jackson-dataformat-yaml/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.9.0,${fasterxml-jackson.version})"
+                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}" mode="maven" />
+
+        <!-- [PPP-4108] Use of vulnerable component jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 -->
+        <bundle
+            originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
+            replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.codehaus.jackson/jackson-mapper-asl/[1.5.0,${codehaus-jackson.version})"
+            replacement="mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus-jackson.version}" mode="maven" />
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -232,7 +232,7 @@
   </feature>
 
   <!-- Separate feature for jackson-* bundles in scope of BACKLOG-20783 -->
-  <feature name="pentaho-jackson" description="Jackson 2.9.x support" version="1.0">
+  <feature name="pentaho-jackson" description="Jackson 2.10.x support" version="1.0">
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -232,7 +232,7 @@
   </feature>
 
   <!-- Separate feature for jackson-* bundles in scope of BACKLOG-20783 -->
-  <feature name="pentaho-jackson" description="Jackson 2.10.x support" version="1.0">
+  <feature name="pentaho-jackson" description="Jackson 2.x support" version="${fasterxml-jackson.version}">
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>


### PR DESCRIPTION
…ckson-databind: CVE-2019-16943 and others

Additional PR to complete work in https://github.com/pentaho/maven-parent-poms/pull/201.
We were pulling `fasterxml-jackson` **2.7.0** which is vulnerable.

@graimundo 