### PR TITLE
[PPP-4461] Reverting change to 'pentaho-jackson' version

### DIFF
--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -232,7 +232,7 @@
   </feature>
 
   <!-- Separate feature for jackson-* bundles in scope of BACKLOG-20783 -->
-  <feature name="pentaho-jackson" description="Jackson 2.x support" version="${fasterxml-jackson.version}">
+  <feature name="pentaho-jackson" description="Jackson 2.x support" version="1.0">
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>


### PR DESCRIPTION
Reverts change in https://github.com/pentaho/pentaho-karaf-assembly/commit/9fe63898dff7da1b5fae7982a21cef7b2fa099ef#diff-ca79bb24347de45717db44dd8a90b0efR235 which is causing the build to fail with the error:

`Unable to build assembly: Could not find matching feature for pentaho-jackson/1.0`

Related to: https://github.com/pentaho/maven-parent-poms/pull/201

@graimundo please review and merge.