### PR TITLE
[SP-5411] Backport of PPP-4461 - Use of Vulnerable Component: com.fas…

### DIFF
--- a/features/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
+++ b/features/pentaho-karaf-features/src/main/resources/pentaho-karaf-features-standard.xml
@@ -159,7 +159,7 @@
 
   <feature name="pentaho-fasterxml" version="1.0">
     <bundle>wrap:mvn:net.sf.flexjson/flexjson/2.1</bundle>
-    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle>mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>
@@ -248,7 +248,7 @@
     <bundle dependency="true">mvn:org.codehaus.jettison/jettison/1.3.5</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
-    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</bundle>
     <bundle dependency="true">mvn:org.scala-lang/scala-library/2.11.0</bundle>
   </feature>
 
@@ -264,10 +264,10 @@
   </feature>
 
   <!-- Separate feature for jackson-* bundles in scope of BACKLOG-20783 -->
-  <feature name="pentaho-jackson" description="Jackson 2.9.x support" version="1.0">
+  <feature name="pentaho-jackson" description="Jackson 2.x support" version="1.0">
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
-    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}</bundle>
     <bundle>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>


### PR DESCRIPTION
…terxml.jackson.core:jackson-databind: CVE-2019-16943 and others (8.3 Suite)

Partial backport of #630 into 8.3 branch.
Related with https://github.com/pentaho/maven-parent-poms/pull/217.

There are many differences between 8.3 and master since 8.3 doesn't have the Karaf upgrade.

@ppatricio 