### PR TITLE
Revert "Merge pull request #634 from gryphendowre/SP-5370"

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -100,7 +100,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version="${commons-vfs2.version}", \
+ org.apache.commons.vfs2.*; version=2.2, \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -94,7 +94,7 @@ org.osgi.framework.system.packages.extra= \
  org.apache.commons.pool.impl, \
  org.apache.commons.vfs, \
  org.apache.commons.vfs.provider.http, \
- org.apache.commons.vfs2.*; version="${commons-vfs2.version}", \
+ org.apache.commons.vfs2.*; version=2.2, \
  org.apache.html.dom; version="2.11.0", \
  org.apache.karaf.branding, \
  org.apache.karaf.service.guard.tools; version="${karaf.version}", \


### PR DESCRIPTION
This reverts commit 98d765768a13421d657061858aa2bb26fcd47408, reversing
changes made to 6cb7bf40f0c12667a2aac10b2e5973b8b8808641.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17