### PR TITLE
[PPP-4497] Use of vulnerable component jstl version 1.0.5 (CVE-2015-0…

### DIFF
--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -51,10 +51,6 @@ org.osgi.framework.system.packages.extra= \
  javax.servlet.jsp.el; version="${jsp-api.version}", \
  javax.servlet.jsp.resources; version="${jsp-api.version}", \
  javax.servlet.jsp.tagext; version="${jsp-api.version}", \
- javax.servlet.jsp.jstl.core; version="${jstl.version}", \
- javax.servlet.jsp.jstl.fmt; version="${jstl.version}", \
- javax.servlet.jsp.jstl.sql; version="${jstl.version}", \
- javax.servlet.jsp.jstl.tlv; version="${jstl.version}", \
  javax.xml.soap, \
  javax.xml.rpc.*, \
  org.apache.commons.collections.*, \

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,6 @@
 
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <jsp-api.version>2.3</jsp-api.version>
-    <jstl.version>1.0.5</jstl.version>
 
     <servicemix.jaxrs-api.version>2.9.1</servicemix.jaxrs-api.version>
 


### PR DESCRIPTION
…254)

Removing `jstl` to address [CVE-2015-0254](https://nvd.nist.gov/vuln/detail/CVE-2015-0254).

Related PRs:
- https://github.com/pentaho/pentaho-platform/pull/4671
- https://github.com/pentaho/pentaho-platform-plugin-jpivot/pull/77
- https://github.com/pentaho/pentaho-karaf-assembly/pull/636
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/291 (this)