### PR TITLE
[PPP-4495] Use of Vulnerable Component: Components/legion-of-the-boun…

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -62,6 +62,11 @@
         <bundle
             originalUri="mvn:org.codehaus.jackson/jackson-mapper-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus-jackson.version}" mode="maven" />
+
+        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,1.65)"
+            replacement="mvn:org.bouncycastle/bcprov-jdk15on/1.65" mode="maven" />
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -64,6 +64,11 @@
         <bundle
             originalUri="mvn:org.codehaus.jackson/jackson-mapper-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-mapper-asl/${codehaus-jackson.version}" mode="maven" />
+
+        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,1.65)"
+            replacement="mvn:org.bouncycastle/bcprov-jdk15on/1.65" mode="maven" />
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->


### PR DESCRIPTION
…cy-castle-java-crytography-api

- Bumping `bcprov-jdk14` to version 1.65
- Version 1.65 was released **Apr 06, 2020**
- Need to use bundle replacements to override the version pulled by some features

Related PRs:
1. https://github.com/pentaho/modeler/pull/365
2. https://github.com/pentaho/pentaho-kettle/pull/7450
3. https://github.com/pentaho/pentaho-platform/pull/4689
4. https://github.com/pentaho/pentaho-reporting/pull/1347
5. https://github.com/pentaho/big-data-plugin/pull/2059
6. https://github.com/pentaho/pentaho-big-data-ee/pull/447
7. https://github.com/pentaho/pentaho-karaf-assembly/pull/640 (this one)