### PR TITLE
[PDI-18657] Memory leak when customer executes jobs on the server

### DIFF
--- a/pentaho-osgi-config/src/main/resources/pentaho.metaverse.cfg
+++ b/pentaho-osgi-config/src/main/resources/pentaho.metaverse.cfg
@@ -34,3 +34,10 @@ lineage.generate.subgraphs=true
 # Default value: true
 #
 lineage.consolidate.subgraphs=true
+
+#
+# Determine the cache eviction time (in seconds) for external resource objects.
+# Default value: 21600
+#
+lineage.external.resource.cache.expire.time=21600
+


### PR DESCRIPTION
- add property "lineage.external.resource.cache.expire.time" to pentaho.metaverse.cfg