### PR TITLE
[BACKLOG-35000] Adding com.hitachivantara.security.web packages to custom.properties

### DIFF
--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -165,7 +165,8 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.mongo.wrapper.field.*;version="${pentaho-osgi-bundles.version}", \
  com.mongodb.*;version="3.10.2", \
  com.mongodb.util.*;version="3.10.2", \
- org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}"
+ org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}", \
+ com.hitachivantara.security.web.api.*;version="${hv-security-web.version}"
 
 karaf.log=${catalina.home}/logs
 karaf.shutdown.port=-1

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -209,6 +209,7 @@
 
     <bundle dependency="true">wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
+    <bundle dependency="true">mvn:com.hitachivantara.security.web/csrf-token-service-client-java-jax-rs-v1/${hv-security-web.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${pdi-data-refinery-plugin.version}</bundle>
   </feature>
 


### PR DESCRIPTION
- Adding com.hitachivantara.security.web.api.* packages to server custom.properties
- Add CSRF client dependency to pdi data refinery feature

Previous code review PR: https://github.com/pentaho/pentaho-karaf-assembly/pull/651.

Part of the changeset described in https://github.com/pentaho/security-web/pull/4#issuecomment-888511840.