### PR TITLE
[PDI-19163] Upgraded mongo java driver version from 3.10.2 to 3.12.10

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -188,8 +188,8 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.di.trans.steps.mongodbinput.*;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.di.trans.steps.mongodboutput.*;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.mongo.wrapper.field.*;version="${pentaho-osgi-bundles.version}", \
- com.mongodb.*;version="3.10.2", \
- com.mongodb.util.*;version="3.10.2", \
+ com.mongodb.*;version="3.12.10", \
+ com.mongodb.util.*;version="3.12.10", \
  org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}"
 
 karaf.shutdown.port=-1

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -163,8 +163,8 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.di.trans.steps.mongodbinput.*;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.di.trans.steps.mongodboutput.*;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.mongo.wrapper.field.*;version="${pentaho-osgi-bundles.version}", \
- com.mongodb.*;version="3.10.2", \
- com.mongodb.util.*;version="3.10.2", \
+ com.mongodb.*;version="3.12.10", \
+ com.mongodb.util.*;version="3.12.10", \
  org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}", \
  com.hitachivantara.security.web.api.*;version="${hv-security-web.version}"
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </modules>
 
   <properties>
-    <mongo.java.driver.version>3.10.2</mongo.java.driver.version>
+    <mongo.java.driver.version>3.12.10</mongo.java.driver.version>
     <org.ehcache.version>1.0.0</org.ehcache.version>
     <pdi-data-refinery-plugin.version>9.3.0.0-SNAPSHOT</pdi-data-refinery-plugin.version>
     <pdi-plugins-ee.version>9.3.0.0-SNAPSHOT</pdi-plugins-ee.version>


### PR DESCRIPTION
Upgrading java mongo driver to the latest possible version without many changes in the code.