### PR TITLE
[SP-6107] Upgrade log4j2 (use HV pax-logging wraps)

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -70,10 +70,10 @@
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"
-            replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version}" mode="maven" />
+            replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/[1,${pax-logging.version})"
-            replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version}" mode="maven" />
+            replacement="mvn:org.hitachivantara/pax-logging-log4j2-wrap/${pax-logging.version}" mode="maven" />
 
     </bundleReplacements>
 

--- a/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
@@ -39,7 +39,7 @@ mvn\:org.fusesource.jansi/jansi/${jansi.version} = 8
 # mvn\:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version} = 8
 mvn\:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version} = 8
 
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version} = 8
+mvn\:org.hitachivantara/pax-logging-log4j2-wrap/${pax-logging.version} = 8
 mvn\:org.apache.felix/org.apache.felix.coordinator/${felix.coordinator.version} = 9
 mvn\:org.apache.felix/org.apache.felix.configadmin/${felix.configadmin.version} = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/${felix.fileinstall.version} = 11

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -72,10 +72,10 @@
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"
-            replacement="mvn:org.ops4j.pax.logging/pax-logging-api/${pax-logging.version}" mode="maven" />
+            replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/[1,${pax-logging.version})"
-            replacement="mvn:org.ops4j.pax.logging/pax-logging-log4j2/${pax-logging.version}" mode="maven" />
+            replacement="mvn:org.hitachivantara/pax-logging-log4j2-wrap/${pax-logging.version}" mode="maven" />
 
     </bundleReplacements>
 

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -82,6 +82,7 @@
          (there's no way to tell the requirement is satisfied by the system bundle).
     -->
     <bundle dependency="true">mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}</bundle>
+    <bundle dependency="true">mvn:org.hitachivantara/pax-logging-log4j2-wrap/${pax-logging.version}</bundle>
 
     <feature prerequisite="true">karaf-base</feature>
 


### PR DESCRIPTION
Assure that we use HV pax-logging wraps (pax-logging-api-wrap and pax-logging-log4j2-wrap).

@rmansoor 