### PR TITLE
[BISERVER-14720] - Upgrade Log4j2 - pax-logging 1.11.13 and log4j2 2.…

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -72,14 +72,6 @@
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"
             replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/[1,${pax-logging.version})"
-            replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.hitachivantara/pax-logging-api-wrap/[1,${pax-logging.version})"
-            replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
-
-
 
     </bundleReplacements>
 

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -73,9 +73,6 @@
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"
             replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.ops4j.pax.logging/pax-logging-log4j2/[1,${pax-logging.version})"
-            replacement="mvn:org.hitachivantara/pax-logging-api-wrap/${pax-logging.version}" mode="maven" />
 
     </bundleReplacements>
 


### PR DESCRIPTION
…17.1

No need to replace 'pax-logging-log4j2'.

@rmansoor @andreramos89 @peterrinehart