### PR TITLE
[BACKLOG-35743] Ensure slf4j-api library is not pulled into karaf as a

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -13,7 +13,9 @@
     <blacklistedFeatures></blacklistedFeatures>
 
     <!-- A list of blacklisted bundle URIs that are not installed even if they are part of some features -->
-    <blacklistedBundles></blacklistedBundles>
+    <blacklistedBundles>
+        <bundle>mvn:org.slf4j/slf4j-api/[1,9)</bundle>
+    </blacklistedBundles>
 
     <!-- A list of repository URIs, feature identifiers and bundle URIs to override "dependency" flag -->
     <overrideBundleDependency></overrideBundleDependency>

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -14,7 +14,9 @@
     <blacklistedFeatures></blacklistedFeatures>
 
     <!-- A list of blacklisted bundle URIs that are not installed even if they are part of some features -->
-    <blacklistedBundles></blacklistedBundles>
+    <blacklistedBundles>
+        <bundle>mvn:org.slf4j/slf4j-api/[1,9)</bundle>
+    </blacklistedBundles>
 
     <!-- A list of repository URIs, feature identifiers and bundle URIs to override "dependency" flag -->
     <overrideBundleDependency></overrideBundleDependency>


### PR DESCRIPTION
bundle; it should only come from the main classpath.
This commit is a cherry-pick from master 7eac453