### PR TITLE
[BACKLOG-36184] Remove references to metaverse-core; this has been moved

### DIFF
--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -157,9 +157,6 @@
 
   <feature name="pentaho-metaverse" version="${project.version}">
     <details>Provides data lineage capabilities</details>
-    <configfile finalname="/etc/pentaho.metaverse.cfg">
-      mvn:pentaho/pentaho-osgi-config/${project.version}/cfg/pentaho-metaverse
-    </configfile>
 
     <feature>pentaho-client</feature>
     <feature>pentaho-tinkerpop-gremlin</feature>
@@ -170,7 +167,6 @@
     </conditional>
 
     <feature>pentaho-fasterxml</feature>
-    <bundle>mvn:pentaho/pentaho-metaverse-core/${pentaho-metaverse.version}</bundle>
   </feature>
 
   <feature name="pentaho-fasterxml" version="1.0">

--- a/pentaho-osgi-config/pom.xml
+++ b/pentaho-osgi-config/pom.xml
@@ -36,11 +36,6 @@
                   <classifier>pdi-monitoring</classifier>
                 </artifact>
                 <artifact>
-                  <file>src/main/resources/pentaho.metaverse.cfg</file>
-                  <type>cfg</type>
-                  <classifier>pentaho-metaverse</classifier>
-                </artifact>
-                <artifact>
                   <file>src/main/resources/pentaho.geo.roles.cfg</file>
                   <type>cfg</type>
                   <classifier>pentaho-geo-roles</classifier>


### PR DESCRIPTION
to a kettle plugin.  metaverse-web still exists.