### PR TITLE
[BACKLOG-37531] Bouncycastle release/version mismatch causing problems

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -197,7 +197,8 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.mongo.wrapper.field.*;version="${pentaho-osgi-bundles.version}", \
  com.mongodb.*;version="3.12.10", \
  com.mongodb.util.*;version="3.12.10", \
- org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}"
+ org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}",\
+ org.bouncycastle.*;version="${bcprov-jdk15to18.version}"
 
 karaf.shutdown.port=-1
 org.osgi.framework.storage.clean=none

--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -15,6 +15,10 @@
     <!-- A list of blacklisted bundle URIs that are not installed even if they are part of some features -->
     <blacklistedBundles>
         <bundle>mvn:org.slf4j/slf4j-api/[1,9)</bundle>
+        <bundle>mvn:org.bouncycastle/bcprov-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcutil-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcpkix-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcmail-jdk15on/[0,900)</bundle>
     </blacklistedBundles>
 
     <!-- A list of repository URIs, feature identifiers and bundle URIs to override "dependency" flag -->
@@ -68,8 +72,17 @@
 
         <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15on.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15on/${bcprov-jdk15on.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -170,7 +170,8 @@ org.osgi.framework.system.packages.extra= \
  com.mongodb.*;version="3.12.10", \
  com.mongodb.util.*;version="3.12.10", \
  org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}", \
- com.hitachivantara.security.web.api.*;version="${hv-security-web.version}"
+ com.hitachivantara.security.web.api.*;version="${hv-security-web.version}",\
+ org.bouncycastle.*;version="${bcprov-jdk15to18.version}"
 
 karaf.log=${catalina.home}/logs
 karaf.shutdown.port=-1

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -16,6 +16,10 @@
     <!-- A list of blacklisted bundle URIs that are not installed even if they are part of some features -->
     <blacklistedBundles>
         <bundle>mvn:org.slf4j/slf4j-api/[1,9)</bundle>
+        <bundle>mvn:org.bouncycastle/bcprov-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcutil-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcpkix-jdk15on/[0,900)</bundle>
+        <bundle>mvn:org.bouncycastle/bcmail-jdk15on/[0,900)</bundle>
     </blacklistedBundles>
 
     <!-- A list of repository URIs, feature identifiers and bundle URIs to override "dependency" flag -->
@@ -69,8 +73,17 @@
 
         <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15on.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15on/${bcprov-jdk15on.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+        <bundle
+            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
+            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"


### PR DESCRIPTION
for karaf ssh service (and presumably anything else in karaf reliant on them).  Standardizing on the jdk15to18 packages since these still work on JDK1.8 (they are not multiversion jars).
This commit is a cherry-pick from master e214073