### PR TITLE
[BACKLOG-39435] OSGI is not able to load Guava bundle after upgradation.

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/startup.properties
@@ -50,6 +50,7 @@ mvn\:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/
 
 #Pentaho deployment dependencies
 mvn\:com.googlecode.json-simple/json-simple/${json.simple.version} = 6
+mvn\:com.google.guava/failureaccess/1.0.1 = 6
 mvn\:com.google.guava/guava/${guava.version} = 6
 mvn\:commons-io/commons-io/${commons-io.version} = 6
 mvn\:commons-lang/commons-lang/${commons.lang.version} = 6

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -38,7 +38,6 @@
 
     <bundle dependency="true">mvn:com.googlecode.json-simple/json-simple/${json.simple.version}</bundle>
     <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
-    <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
     <bundle dependency="true">mvn:com.google.guava/failureaccess/${failureaccess.version}</bundle>
     <bundle dependency="true">mvn:com.google.code.findbugs/jsr305/${jsr305.version}</bundle>
     <bundle dependency="true">mvn:commons-io/commons-io/${commons.io.version}</bundle>


### PR DESCRIPTION
[BACKLOG-39435] OSGI is not able to load Guava bundle after upgradation.

[BACKLOG-39435]: https://hv-eng.atlassian.net/browse/BACKLOG-39435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ