### PR TITLE
[BACKLOG-39584] Changes required to get karaf to start under JDK17.

### DIFF
--- a/assemblies/common-resources/src/main/resources/etc/config.properties
+++ b/assemblies/common-resources/src/main/resources/etc/config.properties
@@ -1,0 +1,307 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# This file lists Karaf default settings for this particular version of Karaf.
+# For easier maintenance when upgrading Karaf and to better document which
+# default values have changed, it is recommended to place any changes to
+# these values in a custom.properties file in the same folder as this file.
+# Each value specified in custom.properties will override the default value
+# here.
+#
+
+#
+# Properties file inclusions (as a space separated list of relative paths)
+# Included files will override the values specified in this file
+# NB: ${includes} properties files are mandatory, it means that Karaf will not start
+# if the include file is not found
+#
+${includes} = jre.properties custom.properties
+
+#
+# Properties file inclusions (as a space separated list of relative paths)
+# Included files will override the values specified in this file
+# NB: ${optionals} properties files are optionals, it means that Karaf will just
+# display a warning message but the bootstrap will be performed
+#
+# ${optionals} = my.properties
+
+#
+# Framework selection properties
+#
+karaf.framework=felix
+
+#
+# Location of the OSGi frameworks
+#
+karaf.framework.equinox=mvn\:org.eclipse.platform/org.eclipse.osgi/3.13.300
+karaf.framework.felix=mvn\:org.apache.felix/org.apache.felix.framework/5.6.12
+
+#
+# Framework config properties.
+#
+org.osgi.framework.system.packages= \
+ org.osgi.dto;version="1.0",\
+ org.osgi.resource;version="1.0",\
+ org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",\
+ org.osgi.framework;version="1.8",\
+ org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",\
+ org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",\
+ org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",\
+ org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",\
+ org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",\
+ org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",\
+ org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",\
+ org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",\
+ org.osgi.framework.wiring.dto;version="1.2";uses:="org.osgi.dto,org.osgi.resource.dto",\
+ org.osgi.service.condpermadmin;version="1.1.1";uses:="org.osgi.framework,org.osgi.service.permissionadmin",\
+ org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",org.osgi.service.permissionadmin;version="1.2",\
+ org.osgi.service.resolver;version="1.0";uses:="org.osgi.resource",\
+ org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",\
+ org.osgi.service.url;version="1.0",\
+ org.osgi.util.tracker;version="1.5.1";uses:="org.osgi.framework",\
+ org.apache.karaf.version;version="4.2.15",\
+ org.apache.karaf.jaas.boot.principal;uses:=javax.security.auth;version="4.2.15",\
+ org.apache.karaf.jaas.boot;uses:="javax.security.auth,javax.security.auth.callback,javax.security.auth.login,javax.security.auth.spi,org.osgi.framework";version="4.2.15",\
+ org.apache.karaf.info;version="4.2.15",\
+ ${jre-${java.specification.version}}
+
+#
+# Extra packages appended after standard packages
+#
+org.osgi.framework.system.packages.extra = \
+    org.apache.karaf.branding, \
+    sun.misc, \
+    com.sun.jmx.remote.protocol, \
+    com.sun.jmx.remote.protocol.jmxmp, \
+    org.apache.karaf.diagnostic.core;uses:=org.osgi.framework;version=4.2.15, \
+    org.apache.karaf.diagnostic.core.common;uses:=org.apache.karaf.diagnostic.core;version=4.2.15, \
+    org.apache.karaf.jaas.boot.principal;uses:=javax.security.auth;version=4.2.15, \
+    org.apache.karaf.jaas.boot;uses:=\"javax.security.auth,javax.security.auth.callback,javax.security.auth.login,javax.security.auth.spi,org.osgi.framework\";version=4.2.15
+
+org.osgi.framework.system.capabilities= \
+ ${eecap-${java.specification.version}}, \
+ ${${karaf.framework}-capabilities}, \
+ ${karaf-capabilities}
+
+karaf-capabilities= \
+ osgi.service;objectClass:List<String>=org.apache.karaf.info.ServerInfo
+
+felix-capabilities= \
+ osgi.service;objectClass:List<String>=org.osgi.service.packageadmin.PackageAdmin, \
+ osgi.service;objectClass:List<String>=org.osgi.service.resolver.Resolver, \
+ osgi.service;objectClass:List<String>=org.osgi.service.startlevel.StartLevel
+
+equinox-capabilities= \
+ osgi.service;objectClass:List<String>=java.lang.ClassLoader;equinox.classloader.type=contextClassLoader, \
+ osgi.service;objectClass:List<String>=javax.xml.parsers.DocumentBuilderFactory, \
+ osgi.service;objectClass:List<String>=javax.xml.parsers.SAXParserFactory, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.framework.log.FrameworkLog, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.framework.log.FrameworkLog;performance=true, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.datalocation.Location;type=eclipse.home.location, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.datalocation.Location;type=osgi.configuration.area, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.datalocation.Location;type=osgi.install.area, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.datalocation.Location;type=osgi.instance.area, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.datalocation.Location;type=osgi.user.area, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.debug.DebugOptions, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.environment.EnvironmentInfo, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.localization.BundleLocalization, \
+ osgi.service;objectClass:List<String>="org.osgi.service.log.LogReaderService,org.eclipse.equinox.log.ExtendedLogReaderService", \
+ osgi.service;objectClass:List<String>="org.osgi.service.log.LogService,org.eclipse.equinox.log.ExtendedLogService", \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.security.TrustEngine;osgi.signedcontent.trust.engine=org.eclipse.osgi, \
+ osgi.service;objectClass:List<String>=org.eclipse.osgi.service.urlconversion.URLConverter;protocol:List<String>="bundleentry,bundleresource"
+
+eecap-17 = osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0,17.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0,17.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0,17.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0,17.0"
+eecap-16 = osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0,16.0"
+eecap-15 = osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0,13.0,14.0,15.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0,15.0"
+eecap-14 = osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0,13.0,14.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0,13.0,14.0"
+eecap-13 = osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0,13.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0,13.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0,13.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0,13.0"
+eecap-11= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0,11.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0,11.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0,11.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0,11.0"
+eecap-10= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0,10.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0,10.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0,10.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0,10.0"
+eecap-9= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8,9.0", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8,9.0", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8,9.0", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8,9.0"
+eecap-1.8= osgi.ee; osgi.ee="OSGi/Minimum"; version:List<Version>="1.0,1.1,1.2", \
+ osgi.ee; osgi.ee="JavaSE"; version:List<Version>="1.0,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8", \
+ osgi.ee; osgi.ee="JRE"; version:List<Version>="1.0,1.1", \
+ osgi.ee; osgi.ee="JavaSE/compact1"; version:List<Version>="1.8", \
+ osgi.ee; osgi.ee="JavaSE/compact2"; version:List<Version>="1.8", \
+ osgi.ee; osgi.ee="JavaSE/compact3"; version:List<Version>="1.8"
+
+#
+# javax.transaction is needed ONLY for com.sun.corba.se.impl.javax.rmi.CORBA.Util.mapSystemException().
+# JDK8 and earlier provide only 3 exception classes in this package, so full JTA API bundles should always try the
+# bootdelegation first - even if they also package (and export) javax.transaction package
+#
+# boot delegation of javax.transaction.xa is needed to avoid class loader constraint violation when using javax.sql
+# and this package is always complete in all JDKs
+#
+org.osgi.framework.bootdelegation = \
+    com.sun.*, \
+    javax.transaction, \
+    javax.transaction.xa, \
+    javax.xml.crypto, \
+    javax.xml.crypto.*, \
+    jdk.nashorn.*, \
+    sun.*, \
+    jdk.internal.reflect, \
+    jdk.internal.reflect.*, \
+    org.apache.karaf.jaas.boot.principal, \
+    org.apache.karaf.jaas.boot
+
+# jVisualVM support
+# in order to use Karaf with jvisualvm, the org.osgi.framework.bootdelegation property has to contain the org.netbeans.lib.profiler.server package
+# and, so, it should look like:
+#
+# org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,org.netbeans.lib.profiler.server
+#
+# YourKit support
+# in order to use Karaf with YourKit, the org.osgi.framework.bootdelegation property has to contain the com.yourkit.* packages
+# and, so, it should look like:
+#
+# org.osgi.framework.bootdelegation=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,com.yourkit.*
+#
+
+#
+# Set the parent classloader for the bundle to the classloader that loads the Framework (i.e. everything in lib/*.jar)
+#
+org.osgi.framework.bundle.parent=framework
+
+#
+# Definition of the default bundle start level
+#
+org.osgi.framework.startlevel.beginning=100
+karaf.startlevel.bundle=80
+
+#
+# The location of the Karaf shutdown port file used to stop instance
+#
+karaf.shutdown.port.file=${karaf.data}/port
+
+#
+# The location of the Karaf pid file
+#
+karaf.pid.file=${karaf.base}/karaf.pid
+
+#
+# Configuration FileMonitor properties
+#
+felix.fileinstall.enableConfigSave = true
+felix.fileinstall.dir    = ${karaf.etc}
+felix.fileinstall.filter = .*\\.(cfg|config)
+felix.fileinstall.poll   = 1000
+felix.fileinstall.noInitialDelay = true
+felix.fileinstall.log.level = 3
+felix.fileinstall.log.default = jul
+
+# Use cached urls for bundle CodeSource to avoid
+# problems with JCE cached informations, see KARAF-3974
+felix.bundlecodesource.usecachedurls = true
+
+#
+# Delay for writing the framework state to disk in equinox
+# must be  >= 1000 and <= 1800000
+#
+eclipse.stateSaveDelayInterval = 1000
+
+#
+# OBR Repository list
+# This property will be modified by the obr:addUrl and obr:removeUrl commands. 
+#
+obr.repository.url = 
+
+#
+# Start blueprint bundles synchronously when possible
+#
+org.apache.aries.blueprint.synchronous=true
+
+#
+# Do not weave all any classes by default
+#
+org.apache.aries.proxy.weaving.enabled=
+
+#
+# mvn url handler requires config instance configuration
+#
+org.ops4j.pax.url.mvn.requireConfigAdminConfig=true
+
+#
+# Don't delay the console startup. Set to true if you want the console to start after all other bundles
+#
+karaf.delay.console=false
+
+#
+# Generated command shutdown
+#
+karaf.shutdown.command = 74f51409-4c11-4e8c-a2c3-907e88947444
+
+#
+# Enable native Karaf support for systemd's watchdog.
+#
+# In addition to setting the flag to true, the JNA library needs to be made
+# available to the main classloader by adding the two following libraries
+# to the lib/boot directory
+#   mvn:net.java.dev.jna/jna/${jna.version}
+#   mvn:net.java.dev.jna/jna-platform/${jna.version}
+# or by building a custom distribution and adding the following lines for the
+# karaf maven plugin configuration:
+#    <library>mvn:net.java.dev.jna/jna/${jna.version};type:=boot;export:=false</library>
+#    <library>mvn:net.java.dev.jna/jna-platform/${jna.version};type:=boot;export:=false</library>
+#
+#karaf.systemd.enabled=true

--- a/assemblies/common-resources/src/main/resources/etc/jre.properties
+++ b/assemblies/common-resources/src/main/resources/etc/jre.properties
@@ -1,0 +1,745 @@
+################################################################################
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+################################################################################
+
+#
+# Java platform package export properties.
+#
+
+# Standard package set.  Note that:
+#   - javax.transaction* is exported with a mandatory attribute
+jre-1.6= \
+ javax.accessibility, \
+ javax.activation;version="1.1", \
+ javax.activity, \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
+ javax.crypto, \
+ javax.crypto.interfaces, \
+ javax.crypto.spec, \
+ javax.imageio, \
+ javax.imageio.event, \
+ javax.imageio.metadata, \
+ javax.imageio.plugins.bmp, \
+ javax.imageio.plugins.jpeg, \
+ javax.imageio.spi, \
+ javax.imageio.stream, \
+ javax.jws, \
+ javax.jws.soap, \
+ javax.lang.model, \
+ javax.lang.model.element, \
+ javax.lang.model.type, \
+ javax.lang.model.util, \
+ javax.management, \
+ javax.management.loading, \
+ javax.management.modelmbean, \
+ javax.management.monitor, \
+ javax.management.openmbean, \
+ javax.management.relation, \
+ javax.management.remote, \
+ javax.management.remote.rmi, \
+ javax.management.timer, \
+ javax.naming, \
+ javax.naming.directory, \
+ javax.naming.event, \
+ javax.naming.ldap, \
+ javax.naming.spi, \
+ javax.net, \
+ javax.net.ssl, \
+ javax.print, \
+ javax.print.attribute, \
+ javax.print.attribute.standard, \
+ javax.print.event, \
+ javax.rmi, \
+ javax.rmi.CORBA, \
+ javax.rmi.ssl, \
+ javax.script, \
+ javax.security.auth, \
+ javax.security.auth.callback, \
+ javax.security.auth.kerberos, \
+ javax.security.auth.login, \
+ javax.security.auth.spi, \
+ javax.security.auth.x500, \
+ javax.security.cert, \
+ javax.security.sasl, \
+ javax.sound.midi, \
+ javax.sound.midi.spi, \
+ javax.sound.sampled, \
+ javax.sound.sampled.spi, \
+ javax.sql, \
+ javax.sql.rowset, \
+ javax.sql.rowset.serial, \
+ javax.sql.rowset.spi, \
+ javax.swing, \
+ javax.swing.border, \
+ javax.swing.colorchooser, \
+ javax.swing.event, \
+ javax.swing.filechooser, \
+ javax.swing.plaf, \
+ javax.swing.plaf.basic, \
+ javax.swing.plaf.metal, \
+ javax.swing.plaf.multi, \
+ javax.swing.plaf.synth, \
+ javax.swing.table, \
+ javax.swing.text, \
+ javax.swing.text.html, \
+ javax.swing.text.html.parser, \
+ javax.swing.text.rtf, \
+ javax.swing.tree, \
+ javax.swing.undo, \
+ javax.tools, \
+ javax.transaction; javax.transaction.xa; partial=true; mandatory:=partial, \
+ javax.xml, \
+ javax.xml.bind;version="2.2.1", \
+ javax.xml.bind.annotation;version="2.2.1", \
+ javax.xml.bind.annotation.adapters;version="2.2.1", \
+ javax.xml.bind.attachment;version="2.2.1", \
+ javax.xml.bind.helpers;version="2.2.1", \
+ javax.xml.bind.util;version="2.2.1", \
+ javax.xml.crypto, \
+ javax.xml.crypto.dom, \
+ javax.xml.crypto.dsig, \
+ javax.xml.crypto.dsig.dom, \
+ javax.xml.crypto.dsig.keyinfo, \
+ javax.xml.crypto.dsig.spec, \
+ javax.xml.datatype, \
+ javax.xml.namespace, \
+ javax.xml.parsers, \
+ javax.xml.soap;version="1.3", \
+ javax.xml.stream;version="1.2", \
+ javax.xml.stream.events;version="1.2", \
+ javax.xml.stream.util;version="1.2", \
+ javax.xml.transform, \
+ javax.xml.transform.dom, \
+ javax.xml.transform.sax, \
+ javax.xml.transform.stax, \
+ javax.xml.transform.stream, \
+ javax.xml.validation, \
+ javax.xml.ws;version="2.2", \
+ javax.xml.ws.handler;version="2.2", \
+ javax.xml.ws.handler.soap;version="2.2", \
+ javax.xml.ws.http;version="2.2", \
+ javax.xml.ws.soap;version="2.2", \
+ javax.xml.ws.spi;version="2.2", \
+ javax.xml.ws.wsaddressing;version="2.2", \
+ javax.xml.ws.spi.http;version="2.2", \
+ javax.xml.xpath, \
+ org.ietf.jgss, \
+ org.omg.CORBA, \
+ org.omg.CORBA_2_3, \
+ org.omg.CORBA_2_3.portable, \
+ org.omg.CORBA.DynAnyPackage, \
+ org.omg.CORBA.ORBPackage, \
+ org.omg.CORBA.portable, \
+ org.omg.CORBA.TypeCodePackage, \
+ org.omg.CosNaming, \
+ org.omg.CosNaming.NamingContextExtPackage, \
+ org.omg.CosNaming.NamingContextPackage, \
+ org.omg.Dynamic, \
+ org.omg.DynamicAny, \
+ org.omg.DynamicAny.DynAnyFactoryPackage, \
+ org.omg.DynamicAny.DynAnyPackage, \
+ org.omg.IOP, \
+ org.omg.IOP.CodecFactoryPackage, \
+ org.omg.IOP.CodecPackage, \
+ org.omg.Messaging, \
+ org.omg.PortableInterceptor, \
+ org.omg.PortableInterceptor.ORBInitInfoPackage, \
+ org.omg.PortableServer, \
+ org.omg.PortableServer.CurrentPackage, \
+ org.omg.PortableServer.POAManagerPackage, \
+ org.omg.PortableServer.POAPackage, \
+ org.omg.PortableServer.portable, \
+ org.omg.PortableServer.ServantLocatorPackage, \
+ org.omg.SendingContext, \
+ org.omg.stub.java.rmi, \
+ org.omg.stub.javax.management.remote.rmi, \
+ org.w3c.dom, \
+ org.w3c.dom.bootstrap, \
+ org.w3c.dom.css, \
+ org.w3c.dom.events, \
+ org.w3c.dom.html, \
+ org.w3c.dom.ls, \
+ org.w3c.dom.ranges, \
+ org.w3c.dom.stylesheets, \
+ org.w3c.dom.traversal, \
+ org.w3c.dom.views, \
+ org.w3c.dom.xpath, \
+ org.xml.sax, \
+ org.xml.sax.ext, \
+ org.xml.sax.helpers
+
+# Standard package set.  Note that:
+#   - javax.transaction* is exported with a mandatory attribute
+jre-1.7= \
+ javax.accessibility, \
+ javax.activation;version="1.1", \
+ javax.activity, \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
+ javax.crypto, \
+ javax.crypto.interfaces, \
+ javax.crypto.spec, \
+ javax.imageio, \
+ javax.imageio.event, \
+ javax.imageio.metadata, \
+ javax.imageio.plugins.bmp, \
+ javax.imageio.plugins.jpeg, \
+ javax.imageio.spi, \
+ javax.imageio.stream, \
+ javax.jws, \
+ javax.jws.soap, \
+ javax.lang.model, \
+ javax.lang.model.element, \
+ javax.lang.model.type, \
+ javax.lang.model.util, \
+ javax.management, \
+ javax.management.loading, \
+ javax.management.modelmbean, \
+ javax.management.monitor, \
+ javax.management.openmbean, \
+ javax.management.relation, \
+ javax.management.remote, \
+ javax.management.remote.rmi, \
+ javax.management.timer, \
+ javax.naming, \
+ javax.naming.directory, \
+ javax.naming.event, \
+ javax.naming.ldap, \
+ javax.naming.spi, \
+ javax.net, \
+ javax.net.ssl, \
+ javax.print, \
+ javax.print.attribute, \
+ javax.print.attribute.standard, \
+ javax.print.event, \
+ javax.rmi, \
+ javax.rmi.CORBA, \
+ javax.rmi.ssl, \
+ javax.script, \
+ javax.security.auth, \
+ javax.security.auth.callback, \
+ javax.security.auth.kerberos, \
+ javax.security.auth.login, \
+ javax.security.auth.spi, \
+ javax.security.auth.x500, \
+ javax.security.cert, \
+ javax.security.sasl, \
+ javax.sound.midi, \
+ javax.sound.midi.spi, \
+ javax.sound.sampled, \
+ javax.sound.sampled.spi, \
+ javax.sql, \
+ javax.sql.rowset, \
+ javax.sql.rowset.serial, \
+ javax.sql.rowset.spi, \
+ javax.swing, \
+ javax.swing.border, \
+ javax.swing.colorchooser, \
+ javax.swing.event, \
+ javax.swing.filechooser, \
+ javax.swing.plaf, \
+ javax.swing.plaf.basic, \
+ javax.swing.plaf.metal, \
+ javax.swing.plaf.multi, \
+ javax.swing.plaf.synth, \
+ javax.swing.table, \
+ javax.swing.text, \
+ javax.swing.text.html, \
+ javax.swing.text.html.parser, \
+ javax.swing.text.rtf, \
+ javax.swing.tree, \
+ javax.swing.undo, \
+ javax.tools, \
+ javax.transaction; javax.transaction.xa; version="1.1"; partial=true; mandatory:=partial, \
+ javax.xml, \
+ javax.xml.bind;version="2.2.1", \
+ javax.xml.bind.annotation;version="2.2.1", \
+ javax.xml.bind.annotation.adapters;version="2.2.1", \
+ javax.xml.bind.attachment;version="2.2.1", \
+ javax.xml.bind.helpers;version="2.2.1", \
+ javax.xml.bind.util;version="2.2.1", \
+ javax.xml.crypto, \
+ javax.xml.crypto.dom, \
+ javax.xml.crypto.dsig, \
+ javax.xml.crypto.dsig.dom, \
+ javax.xml.crypto.dsig.keyinfo, \
+ javax.xml.crypto.dsig.spec, \
+ javax.xml.datatype, \
+ javax.xml.namespace, \
+ javax.xml.parsers, \
+ javax.xml.soap;version="1.3", \
+ javax.xml.stream;version="1.2", \
+ javax.xml.stream.events;version="1.2", \
+ javax.xml.stream.util;version="1.2", \
+ javax.xml.transform, \
+ javax.xml.transform.dom, \
+ javax.xml.transform.sax, \
+ javax.xml.transform.stax, \
+ javax.xml.transform.stream, \
+ javax.xml.validation, \
+ javax.xml.xpath, \
+ org.ietf.jgss, \
+ org.omg.CORBA, \
+ org.omg.CORBA_2_3, \
+ org.omg.CORBA_2_3.portable, \
+ org.omg.CORBA.DynAnyPackage, \
+ org.omg.CORBA.ORBPackage, \
+ org.omg.CORBA.portable, \
+ org.omg.CORBA.TypeCodePackage, \
+ org.omg.CosNaming, \
+ org.omg.CosNaming.NamingContextExtPackage, \
+ org.omg.CosNaming.NamingContextPackage, \
+ org.omg.Dynamic, \
+ org.omg.DynamicAny, \
+ org.omg.DynamicAny.DynAnyFactoryPackage, \
+ org.omg.DynamicAny.DynAnyPackage, \
+ org.omg.IOP, \
+ org.omg.IOP.CodecFactoryPackage, \
+ org.omg.IOP.CodecPackage, \
+ org.omg.Messaging, \
+ org.omg.PortableInterceptor, \
+ org.omg.PortableInterceptor.ORBInitInfoPackage, \
+ org.omg.PortableServer, \
+ org.omg.PortableServer.CurrentPackage, \
+ org.omg.PortableServer.POAManagerPackage, \
+ org.omg.PortableServer.POAPackage, \
+ org.omg.PortableServer.portable, \
+ org.omg.PortableServer.ServantLocatorPackage, \
+ org.omg.SendingContext, \
+ org.omg.stub.java.rmi, \
+ org.omg.stub.javax.management.remote.rmi, \
+ org.w3c.dom, \
+ org.w3c.dom.bootstrap, \
+ org.w3c.dom.css, \
+ org.w3c.dom.events, \
+ org.w3c.dom.html, \
+ org.w3c.dom.ls, \
+ org.w3c.dom.ranges, \
+ org.w3c.dom.stylesheets, \
+ org.w3c.dom.traversal, \
+ org.w3c.dom.views, \
+ org.w3c.dom.xpath, \
+ org.xml.sax, \
+ org.xml.sax.ext, \
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp
+
+#
+# A note about javax.transaction and javax.transaction.xa packages in JDK8 and JDK9+
+# - javax.transaction package is not provided at all in JDK9+ because of the removal of Corba
+# - javax.transaction package in JDK8 and earlier contains only 3 exception classes required to translate 3 Corba/OMG
+#   exception: org.omg.CORBA.TRANSACTION_REQUIRED, org.omg.CORBA.TRANSACTION_ROLLEDBACK, org.omg.CORBA.INVALID_TRANSACTION
+# - javax.transaction.xa package should always be provided by JDK itself (thus exported from system bundle and bootdelegated)
+#   because of javax.sql.XAConnection interface relying on javax.sql.xa.XAResource interface
+# - I decided to export javax.transaction.xa package with all the versions: 1.1, 1.2 and 1.3 just to satisfy all potential
+#   import version ranges (and emphasize the fact that JavaEE doesn't version packages at all)
+# - javax.transaction package should be exported by JDK8 (but not JDK9+) with mandatory attribute ("partial" is an
+#   arbirtary name mentioned in "https://docs.osgi.org/specification/osgi.core/7.0.0/framework.module.html#framework.module.requirebundle"
+# - javax.transaction exported with "partial=true;mandatory:=partial" prevents system bundle to be a wire candidate for
+#   bundles with just "Import-Package: javax.transaction" - actual JTA API bundle is needed to provide all the classes
+#   from this package (like javax.transaction.UserTransaction)
+# - thus javax.transaction package is exported without a version - because each bundle with "Import-Package: javax.transaction"
+#   should always wire to full JTA API bundle. The fact that the JDK8 provided exception classes from this package
+#   are always loaded using boot class loader is an obvious, but internal consequence
+# - the full trick mentioned in "3.13.1 Require-Bundle" requires another bundle that exports javax.transaction package
+#   without mandatory attribute and that has Require-Bundle requirement to a bundle that exports the package with mandatory
+#   attribute - and that's what javax.transaction/javax.transaction-api/1.2 does - it contains "Require-Bundle: system.bundle"
+# - Require-Bundle in JTA API bundle is not needed if javax.transaction is boot-delegated - because failure to search
+#   boot-delegated javax.* packages doesn't stop the class loading process - local content is checked
+# - jakarta.transaction/jakarta.transaction-api/1.3.x doesn't have (by mistake, see https://github.com/eclipse-ee4j/jta-api/issues/186)
+#   "Require-Bundle: system.bundle", but it still works thanks to boot-delegation
+# And last, but important thing - DBCP2 (see DBCP-571) has "Import-Package: javax.transaction.xa;partial=true;mandatory:=partial"
+# which is simply wrong (if anything, javax.transaction package should be imported this way, not javax.transaction.xa),
+# but to allow DBCP2 to be resolved on Karaf, special export package is added just for DBCP2:
+#     Export-Pacakge: javax.transaction.xa;partial=true;mandatory:=partial;version="1.1"
+# - mandatory "partial" attribute is added to javax.transaction export (JDK8) to prevent wiring to this package without
+#   full JTA API bundle
+# - mandatory "partial" attribute is added to javax.transaction.xa export (all JDKs) to satisfy DBCP2
+#
+
+jre-1.8= \
+ javax.accessibility, \
+ javax.activity, \
+ javax.annotation;version="1.0", \
+ javax.annotation.processing;version="1.0", \
+ javax.crypto, \
+ javax.crypto.interfaces, \
+ javax.crypto.spec, \
+ javax.imageio, \
+ javax.imageio.event, \
+ javax.imageio.metadata, \
+ javax.imageio.plugins.bmp, \
+ javax.imageio.plugins.jpeg, \
+ javax.imageio.spi, \
+ javax.imageio.stream, \
+ javax.jws, \
+ javax.jws.soap, \
+ javax.lang.model, \
+ javax.lang.model.element, \
+ javax.lang.model.type, \
+ javax.lang.model.util, \
+ javax.management, \
+ javax.management.loading, \
+ javax.management.modelmbean, \
+ javax.management.monitor, \
+ javax.management.openmbean, \
+ javax.management.relation, \
+ javax.management.remote, \
+ javax.management.remote.rmi, \
+ javax.management.timer, \
+ javax.naming, \
+ javax.naming.directory, \
+ javax.naming.event, \
+ javax.naming.ldap, \
+ javax.naming.spi, \
+ javax.net, \
+ javax.net.ssl, \
+ javax.print, \
+ javax.print.attribute, \
+ javax.print.attribute.standard, \
+ javax.print.event, \
+ javax.rmi, \
+ javax.rmi.CORBA, \
+ javax.rmi.ssl, \
+ javax.script, \
+ javax.security.auth, \
+ javax.security.auth.callback, \
+ javax.security.auth.kerberos, \
+ javax.security.auth.login, \
+ javax.security.auth.spi, \
+ javax.security.auth.x500, \
+ javax.security.cert, \
+ javax.security.sasl, \
+ javax.sound.midi, \
+ javax.sound.midi.spi, \
+ javax.sound.sampled, \
+ javax.sound.sampled.spi, \
+ javax.sql, \
+ javax.sql.rowset, \
+ javax.sql.rowset.serial, \
+ javax.sql.rowset.spi, \
+ javax.swing, \
+ javax.swing.border, \
+ javax.swing.colorchooser, \
+ javax.swing.event, \
+ javax.swing.filechooser, \
+ javax.swing.plaf, \
+ javax.swing.plaf.basic, \
+ javax.swing.plaf.metal, \
+ javax.swing.plaf.multi, \
+ javax.swing.plaf.synth, \
+ javax.swing.table, \
+ javax.swing.text, \
+ javax.swing.text.html, \
+ javax.swing.text.html.parser, \
+ javax.swing.text.rtf, \
+ javax.swing.tree, \
+ javax.swing.undo, \
+ javax.tools, \
+ javax.transaction;partial=true;mandatory:=partial, \
+ javax.transaction.xa;version="1.1";partial=true;mandatory:=partial, \
+ javax.transaction.xa;version="1.1", \
+ javax.transaction.xa;version="1.2", \
+ javax.transaction.xa;version="1.3", \
+ javax.xml, \
+ javax.xml.bind;version="2.2.8", \
+ javax.xml.bind.annotation;version="2.2.8", \
+ javax.xml.bind.annotation.adapters;version="2.2.8", \
+ javax.xml.bind.attachment;version="2.2.8", \
+ javax.xml.bind.helpers;version="2.2.8", \
+ javax.xml.bind.util;version="2.2.8", \
+ javax.xml.crypto, \
+ javax.xml.crypto.dom, \
+ javax.xml.crypto.dsig, \
+ javax.xml.crypto.dsig.dom, \
+ javax.xml.crypto.dsig.keyinfo, \
+ javax.xml.crypto.dsig.spec, \
+ javax.xml.datatype, \
+ javax.xml.namespace, \
+ javax.xml.parsers, \
+ javax.xml.stream;version="1.2", \
+ javax.xml.stream.events;version="1.2", \
+ javax.xml.stream.util;version="1.2", \
+ javax.xml.transform, \
+ javax.xml.transform.dom, \
+ javax.xml.transform.sax, \
+ javax.xml.transform.stax, \
+ javax.xml.transform.stream, \
+ javax.xml.validation, \
+ javax.xml.ws;version="2.2", \
+ javax.xml.ws.handler;version="2.2", \
+ javax.xml.ws.handler.soap;version="2.2", \
+ javax.xml.ws.http;version="2.2", \
+ javax.xml.ws.soap;version="2.2", \
+ javax.xml.ws.spi;version="2.2", \
+ javax.xml.ws.wsaddressing;version="2.2", \
+ javax.xml.ws.spi.http;version="2.2", \
+ javax.xml.xpath, \
+ javafx.animation, \
+ javafx.application, \
+ javafx.beans, \
+ javafx.beans.binding, \
+ javafx.beans.property, \
+ javafx.beans.property.adapter, \
+ javafx.beans.value, \
+ javafx.collections, \
+ javafx.collections.transform, \
+ javafx.concurrent, \
+ javafx.css, \
+ javafx.embed.swing, \
+ javafx.embed.swt, \
+ javafx.event, \
+ javafx.fxml, \
+ javafx.geometry, \
+ javafx.print, \
+ javafx.scene, \
+ javafx.scene.canvas, \
+ javafx.scene.chart, \
+ javafx.scene.control, \
+ javafx.scene.control.cell, \
+ javafx.scene.effect, \
+ javafx.scene.image, \
+ javafx.scene.input, \
+ javafx.scene.layout, \
+ javafx.scene.media, \
+ javafx.scene.paint, \
+ javafx.scene.shape, \
+ javafx.scene.text, \
+ javafx.scene.transform, \
+ javafx.scene.web, \
+ javafx.stage, \
+ javafx.util, \
+ javafx.util.converter, \
+ netscape.javascript, \
+ org.ietf.jgss, \
+ org.omg.CORBA, \
+ org.omg.CORBA_2_3, \
+ org.omg.CORBA_2_3.portable, \
+ org.omg.CORBA.DynAnyPackage, \
+ org.omg.CORBA.ORBPackage, \
+ org.omg.CORBA.portable, \
+ org.omg.CORBA.TypeCodePackage, \
+ org.omg.CosNaming, \
+ org.omg.CosNaming.NamingContextExtPackage, \
+ org.omg.CosNaming.NamingContextPackage, \
+ org.omg.Dynamic, \
+ org.omg.DynamicAny, \
+ org.omg.DynamicAny.DynAnyFactoryPackage, \
+ org.omg.DynamicAny.DynAnyPackage, \
+ org.omg.IOP, \
+ org.omg.IOP.CodecFactoryPackage, \
+ org.omg.IOP.CodecPackage, \
+ org.omg.Messaging, \
+ org.omg.PortableInterceptor, \
+ org.omg.PortableInterceptor.ORBInitInfoPackage, \
+ org.omg.PortableServer, \
+ org.omg.PortableServer.CurrentPackage, \
+ org.omg.PortableServer.POAManagerPackage, \
+ org.omg.PortableServer.POAPackage, \
+ org.omg.PortableServer.portable, \
+ org.omg.PortableServer.ServantLocatorPackage, \
+ org.omg.SendingContext, \
+ org.omg.stub.java.rmi, \
+ org.omg.stub.javax.management.remote.rmi, \
+ org.w3c.dom, \
+ org.w3c.dom.bootstrap, \
+ org.w3c.dom.css, \
+ org.w3c.dom.events, \
+ org.w3c.dom.html, \
+ org.w3c.dom.ls, \
+ org.w3c.dom.ranges, \
+ org.w3c.dom.stylesheets, \
+ org.w3c.dom.traversal, \
+ org.w3c.dom.views, \
+ org.w3c.dom.xpath, \
+ org.xml.sax, \
+ org.xml.sax.ext, \
+ org.xml.sax.helpers, \
+ com.sun.nio.sctp
+
+jre-9= \
+ javax.accessibility, \
+ javax.activity, \
+ javax.annotation;version="1.3", \
+ javax.annotation.processing;version="1.0", \
+ javax.activation;version="1.2.1", \
+ javax.crypto, \
+ javax.crypto.interfaces, \
+ javax.crypto.spec, \
+ javax.imageio, \
+ javax.imageio.event, \
+ javax.imageio.metadata, \
+ javax.imageio.plugins.bmp, \
+ javax.imageio.plugins.jpeg, \
+ javax.imageio.spi, \
+ javax.imageio.stream, \
+ javax.lang.model, \
+ javax.lang.model.element, \
+ javax.lang.model.type, \
+ javax.lang.model.util, \
+ javax.management, \
+ javax.management.loading, \
+ javax.management.modelmbean, \
+ javax.management.monitor, \
+ javax.management.openmbean, \
+ javax.management.relation, \
+ javax.management.remote, \
+ javax.management.remote.rmi, \
+ javax.management.timer, \
+ javax.naming, \
+ javax.naming.directory, \
+ javax.naming.event, \
+ javax.naming.ldap, \
+ javax.naming.spi, \
+ javax.net, \
+ javax.net.ssl, \
+ javax.print, \
+ javax.print.attribute, \
+ javax.print.attribute.standard, \
+ javax.print.event, \
+ javax.rmi, \
+ javax.rmi.ssl, \
+ javax.script, \
+ javax.security.auth, \
+ javax.security.auth.callback, \
+ javax.security.auth.kerberos, \
+ javax.security.auth.login, \
+ javax.security.auth.spi, \
+ javax.security.auth.x500, \
+ javax.security.cert, \
+ javax.security.sasl, \
+ javax.sound.midi, \
+ javax.sound.midi.spi, \
+ javax.sound.sampled, \
+ javax.sound.sampled.spi, \
+ javax.sql, \
+ javax.sql.rowset, \
+ javax.sql.rowset.serial, \
+ javax.sql.rowset.spi, \
+ javax.swing, \
+ javax.swing.border, \
+ javax.swing.colorchooser, \
+ javax.swing.event, \
+ javax.swing.filechooser, \
+ javax.swing.plaf, \
+ javax.swing.plaf.basic, \
+ javax.swing.plaf.metal, \
+ javax.swing.plaf.multi, \
+ javax.swing.plaf.synth, \
+ javax.swing.table, \
+ javax.swing.text, \
+ javax.swing.text.html, \
+ javax.swing.text.html.parser, \
+ javax.swing.text.rtf, \
+ javax.swing.tree, \
+ javax.swing.undo, \
+ javax.tools, \
+ javax.transaction.xa;version="1.1";partial=true;mandatory:=partial, \
+ javax.transaction.xa;version="1.1", \
+ javax.transaction.xa;version="1.2", \
+ javax.transaction.xa;version="1.3", \
+ javax.xml, \
+ javax.xml.bind;version="2.3.0", \
+ javax.xml.bind.annotation;version="2.3.0", \
+ javax.xml.bind.annotation.adapters;version="2.3.0", \
+ javax.xml.bind.attachment;version="2.3.0", \
+ javax.xml.bind.helpers;version="2.3.0", \
+ javax.xml.bind.util;version="2.3.0", \
+ javax.xml.crypto, \
+ javax.xml.crypto.dom, \
+ javax.xml.crypto.dsig, \
+ javax.xml.crypto.dsig.dom, \
+ javax.xml.crypto.dsig.keyinfo, \
+ javax.xml.crypto.dsig.spec, \
+ javax.xml.datatype, \
+ javax.xml.namespace, \
+ javax.xml.parsers, \
+ javax.xml.stream;version="1.2", \
+ javax.xml.stream.events;version="1.2", \
+ javax.xml.stream.util;version="1.2", \
+ javax.xml.transform, \
+ javax.xml.transform.dom, \
+ javax.xml.transform.sax, \
+ javax.xml.transform.stax, \
+ javax.xml.transform.stream, \
+ javax.xml.validation, \
+ javax.xml.xpath, \
+ javafx.animation, \
+ javafx.application, \
+ javafx.beans, \
+ javafx.beans.binding, \
+ javafx.beans.property, \
+ javafx.beans.property.adapter, \
+ javafx.beans.value, \
+ javafx.collections, \
+ javafx.collections.transformation, \
+ javafx.concurrent, \
+ javafx.css, \
+ javafx.embed.swing, \
+ javafx.embed.swt, \
+ javafx.event, \
+ javafx.fxml, \
+ javafx.geometry, \
+ javafx.print, \
+ javafx.scene, \
+ javafx.scene.canvas, \
+ javafx.scene.chart, \
+ javafx.scene.control, \
+ javafx.scene.control.cell, \
+ javafx.scene.effect, \
+ javafx.scene.image, \
+ javafx.scene.input, \
+ javafx.scene.layout, \
+ javafx.scene.media, \
+ javafx.scene.paint, \
+ javafx.scene.shape, \
+ javafx.scene.text, \
+ javafx.scene.transform, \
+ javafx.scene.web, \
+ javafx.stage, \
+ javafx.util, \
+ javafx.util.converter, \
+ netscape.javascript, \
+ org.ietf.jgss, \
+ org.w3c.dom, \
+ org.w3c.dom.bootstrap, \
+ org.w3c.dom.css, \
+ org.w3c.dom.events, \
+ org.w3c.dom.html, \
+ org.w3c.dom.ls, \
+ org.w3c.dom.ranges, \
+ org.w3c.dom.stylesheets, \
+ org.w3c.dom.traversal, \
+ org.w3c.dom.views, \
+ org.w3c.dom.xpath, \
+ org.xml.sax, \
+ org.xml.sax.ext, \
+ org.xml.sax.helpers, \
+ com.sun.security.sasl, \
+ com.sun.security.sasl.digest, \
+ com.sun.security.sasl.ntlm, \
+ com.sun.security.sasl.util 
+
+jre-10 = ${jre-9}
+jre-11 = ${jre-10}
+jre-13 = ${jre-11}
+jre-14 = ${jre-13}
+jre-15 = ${jre-14}
+jre-16 = ${jre-15}
+jre-17 = ${jre-16}


### PR DESCRIPTION
These were copied from karaf 4.3.3 which explicitly supports JDK17. Unknown if these updates plus additional --add-opens are all we will need to keep the existing karaf version working with JDK17, but this is a start.