### PR TITLE
[BACKLOG-41381]-Pentaho Server CE throwing wiring errors on boot

### DIFF
--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -180,7 +180,8 @@ org.osgi.framework.system.packages.extra= \
  com.mongodb.util.*;version="3.12.10", \
  org.pentaho.di.core.namedcluster.*;version="${big-data-plugin.version}", \
  com.hitachivantara.security.web.api.*;version="${hv-security-web.version}",\
- org.bouncycastle.*;version="${bcprov-jdk15to18.version}"
+ org.bouncycastle.*;version="${bcprov-jdk15to18.version}",\
+ mondrian.*;version="${mondrian.version}"
 
 karaf.log=${catalina.home}/logs
 karaf.shutdown.port=-1


### PR DESCRIPTION
[BACKLOG-41381]-Pentaho Server CE throwing wiring errors on boot

[BACKLOG-41381]: https://hv-eng.atlassian.net/browse/BACKLOG-41381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ