### PR TITLE
[SP-6624] Backport of PDI-20219 - Charts do not function in DET in 9.3.0.8 (9.3 Suite)

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -45,6 +45,7 @@ org.osgi.framework.system.packages.extra= \
  com.pentaho.commons.dsc.params, \
  com.pentaho.commons.dsc.tlsup.*, \
  com.pentaho.messages.*, \
+ org.pentaho.commons.util.*, \
  org.pentaho.di.webspoon.*, \
  org.pentaho.hadoop.shim.*, \
  org.pentaho.hadoop.mapreduce.*, \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -118,6 +118,7 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.metaverse.api.*, \
  org.pentaho.osgi.api;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.platform.*, \
+ org.pentaho.commons.util.*, \
  org.pentaho.platform.repository2.*, \
  org.pentaho.platform.proxy.*;version="${pentaho-osgi-bundles.version}", \
  org.pentaho.platform.api.monitoring.snmp;version="${pentaho-osgi-bundles.version}", \


### PR DESCRIPTION
(cherry picked from commit 4c88c6b40cbab94e013131e30232dd36ac1f5c4c) Backport of [BACKLOG-41390] - Adding the package where PermissionDeniedException exists

@pentaho/tatooine_dev 

[BACKLOG-41390]: https://hv-eng.atlassian.net/browse/BACKLOG-41390?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ