### PR TITLE
[BACKLOG-42817]-Upgrading fasterxml jaxrs to fasterxml jakarta rs to support with jersey 3.x and jakarta 3.x

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -60,11 +60,11 @@
                 originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}" mode="maven" />
+                originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/[2.7.0,${fasterxml-jackson.version})"
+                replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}" mode="maven" />
+                originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/[2.7.0,${fasterxml-jackson.version})"
+                replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}" mode="maven" />
 
         <!-- [PPP-4108] Use of vulnerable component jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 -->
         <bundle
@@ -116,11 +116,11 @@
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</f:bundle>
                 <f:bundle start-level="35">mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</f:bundle>
-                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}</f:bundle> -->
-                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
+                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}</f:bundle> -->
+                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
                 <f:feature prerequisite="true">wrap</f:feature>
-                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
-                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
+                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
+                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,3)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
             </feature>
         </replacement>
 

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -62,11 +62,11 @@
                 originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}" mode="maven" />
+                originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/[2.7.0,${fasterxml-jackson.version})"
+                replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}" mode="maven" />
         <bundle
-                originalUri="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}" mode="maven" />
+                originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/[2.7.0,${fasterxml-jackson.version})"
+                replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}" mode="maven" />
 
         <!-- [PPP-4108] Use of vulnerable component jackson-mapper-asl-1.9.2.jar CVE-2017-7525, CVE-2017-15095, CVE-2017-15095 -->
         <bundle
@@ -118,11 +118,11 @@
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</f:bundle>
                 <f:bundle start-level="35">mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</f:bundle>
-                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}</f:bundle> -->
-                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
+                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}</f:bundle> -->
+                <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
                 <f:feature prerequisite="true">wrap</f:feature>
-                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
-                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
+                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
+                <f:bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</f:bundle>
             </feature>
         </replacement>
 

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -226,11 +226,11 @@
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</bundle>
-    <!-- bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}</bundle>
-    <bundle>mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}</bundle -->
+    <!-- bundle>mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}</bundle -->
     <!-- Apply the same wrapping than cxf-jackson feature -->
-    <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
-    <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=javax.ws.rs*;version="[2.0,3)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
+    <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
+    <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
 
     <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${servicemix.jaxrs-api.version}</bundle>


### PR DESCRIPTION
[BACKLOG-42817]-Upgrading fasterxml jaxrs to fasterxml jakarta rs to support with jersey 3.x and jakarta 3.x

[BACKLOG-42817]: https://hv-eng.atlassian.net/browse/BACKLOG-42817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ