### PR TITLE
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -58,7 +58,7 @@
                 replacement="mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}" mode="maven" />
         <bundle
                 originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
+                replacement="mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
                 originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}" mode="maven" />
@@ -115,7 +115,7 @@
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</f:bundle>
                 <f:bundle start-level="35">mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}</f:bundle>
-                <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</f:bundle>
+                <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}</f:bundle>
                 <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}</f:bundle> -->
                 <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
                 <f:feature prerequisite="true">wrap</f:feature>

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -60,7 +60,7 @@
                 replacement="mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}" mode="maven" />
         <bundle
                 originalUri="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/[2.7.0,${fasterxml-jackson.version})"
-                replacement="mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}" mode="maven" />
+                replacement="mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}" mode="maven" />
         <bundle
                 originalUri="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/[2.7.0,${fasterxml-jackson.version})"
                 replacement="mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}" mode="maven" />
@@ -117,7 +117,7 @@
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</f:bundle>
                 <f:bundle start-level="35">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</f:bundle>
                 <f:bundle start-level="35">mvn:org.hitachivantara/jackson-dataformat-yaml/${hv-jackson-dataformat.version}</f:bundle>
-                <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</f:bundle>
+                <f:bundle start-level="35">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}</f:bundle>
                 <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}</f:bundle> -->
                 <!-- <f:bundle start-level="35">mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}</f:bundle> -->
                 <f:feature prerequisite="true">wrap</f:feature>

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -201,7 +201,7 @@
     <bundle dependency="true">wrap:mvn:pentaho/pentaho-modeler/${pentaho-modeler.version}</bundle>
 
     <bundle dependency="true">wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
-    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.hitachivantara.security.web/csrf-token-service-client-java-jax-rs-v3/${hv-security-web.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${pdi-data-refinery-plugin.version}</bundle>
   </feature>
@@ -231,7 +231,7 @@
     <!-- Apply the same wrapping than cxf-jackson feature -->
     <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-base/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
     <bundle dependency="true">wrap:mvn:com.fasterxml.jackson.jakarta.rs/jackson-jakarta-rs-json-provider/${fasterxml-jackson.version}$overwrite=merge&amp;Import-Package=jakarta.ws.rs*;version="[3.1.0,4)",com.fasterxml.jackson.module.jaxb;resolution:=optional;version="[2.8,3)",com.fasterxml.jackson*;version="[2.8,3)"</bundle>
-    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}</bundle>
 
     <bundle dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${servicemix.jaxrs-api.version}</bundle>
   </feature>


### PR DESCRIPTION
[BACKLOG-42955]-Upgrading jackson-module-jaxb-annotations to jackson-module-jakarta-xmlbind-annotations to support Jakarta EE

[BACKLOG-42955]: https://hv-eng.atlassian.net/browse/BACKLOG-42955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ