### PR TITLE
[BACKLOG-40823] - Upgrade the Tomcat version from current to 10.x.x with Java 17

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -70,6 +70,7 @@ org.osgi.framework.system.packages.extra= \
  org.jfree.*, \
  jakarta.annotation.*;version="2.1.1", \
  jakarta.servlet.*;version="6.0.0",\
+ jakarta.xml.bind.*;version="${jakarta.xml.bind-api.version}",\
  jakarta.ws.rs.*;version="3.1.0",\
  org.glassfish.hk2.*;version="3.0.6",\
  org.glassfish.jersey.*;version="3.1.7",\

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -70,12 +70,11 @@ org.osgi.framework.system.packages.extra= \
  org.jfree.*, \
  jakarta.annotation.*;version="2.1.1", \
  jakarta.servlet.*;version="6.0.0",\
- com.google.gwt.*;version="2.11.0", \
- jakarta.websocket.*;version="2.1.0",\
  jakarta.ws.rs.*;version="3.1.0",\
- org.glassfish.hk2.*;version="3.1.7",\
+ org.glassfish.hk2.*;version="3.0.6",\
  org.glassfish.jersey.*;version="3.1.7",\
- org.jvnet.hk2.spring.*;version="2.6.1",\
+ jakarta.inject.*;version="2.0.1",\
+ org.jvnet.hk2.spring.*;version="3.0.6",\
  org.pentaho.reporting.libraries.*, \
  org.apache.commons.collections.*, \
  org.apache.commons.logging.*; version="${commons-logging.version}", \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -68,14 +68,15 @@ org.osgi.framework.system.packages.extra= \
  javax.xml.soap, \
  javax.xml.rpc.*, \
  org.jfree.*, \
- jakarta.annotation.*;version="2.1.1", \
- jakarta.servlet.*;version="6.0.0",\
- jakarta.servlet.http.*;version="6.0.0",\
- jakarta.xml.bind.*;version="${jakarta.xml.bind-api.version}",\
- jakarta.ws.rs.*;version="3.1.0",\
- org.glassfish.hk2.*;version="3.0.6",\
- org.glassfish.jersey.*;version="3.1.7",\
- jakarta.inject.*;version="2.0.1",\
+ jakarta.annotation.*; version="${jakarta.annotation-api.version}", \
+ jakarta.servlet.*; version="${jakarta.servlet.version}", \
+ jakarta.servlet.http.*; version="${jakarta.servlet.version}", \
+ jakarta.xml.bind.*; version="${jakarta.xml.bind-api.version}", \
+ jakarta.ws.rs.*; version="${jakarta.ws.rs-api.version}", \
+ org.glassfish.hk2.*; version="3.0.6", \
+ org.glassfish.jersey.*; version="${jersey.version}", \
+ jakarta.inject.*; version="${jakarta.inject.version}", \
+ jakarta.ws.rs.*; version="3.1.0", \
  org.jvnet.hk2.spring.*;version="3.0.6",\
  org.pentaho.reporting.libraries.*, \
  org.apache.commons.collections.*, \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -68,6 +68,14 @@ org.osgi.framework.system.packages.extra= \
  javax.xml.soap, \
  javax.xml.rpc.*, \
  org.jfree.*, \
+ jakarta.annotation.*;version="2.1.1", \
+ jakarta.servlet.*;version="6.0.0",\
+ com.google.gwt.*;version="2.11.0", \
+ jakarta.websocket.*;version="2.1.0",\
+ jakarta.ws.rs.*;version="3.1.0",\
+ org.glassfish.hk2.*;version="3.1.7",\
+ org.glassfish.jersey.*;version="3.1.7",\
+ org.jvnet.hk2.spring.*;version="2.6.1",\
  org.pentaho.reporting.libraries.*, \
  org.apache.commons.collections.*, \
  org.apache.commons.logging.*; version="${commons-logging.version}", \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -70,6 +70,7 @@ org.osgi.framework.system.packages.extra= \
  org.jfree.*, \
  jakarta.annotation.*;version="2.1.1", \
  jakarta.servlet.*;version="6.0.0",\
+ jakarta.servlet.http.*;version="6.0.0",\
  jakarta.xml.bind.*;version="${jakarta.xml.bind-api.version}",\
  jakarta.ws.rs.*;version="3.1.0",\
  org.glassfish.hk2.*;version="3.0.6",\

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -65,7 +65,6 @@ org.osgi.framework.system.packages.extra= \
  mondrian.xmla.*, \
  org.osjava.sj.*, \
  org.safehaus.uuid, \
- javax.annotation.*;version="1.3.1", \
  javax.xml.soap, \
  javax.xml.rpc.*, \
  org.jfree.*, \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -65,10 +65,9 @@ org.osgi.framework.system.packages.extra= \
  mondrian.xmla.*, \
  org.osjava.sj.*, \
  org.safehaus.uuid, \
- javax.annotation.*;version="1.2", \
+ javax.annotation.*;version="1.3.1", \
  javax.xml.soap, \
  javax.xml.rpc.*, \
- javax.xml.bind.*;version="${jakarta.xml.bind-api.version}", \
  org.jfree.*, \
  org.pentaho.reporting.libraries.*, \
  org.apache.commons.collections.*, \
@@ -158,12 +157,6 @@ org.osgi.framework.system.packages.extra= \
  org.pentaho.database.*, \
  com.thoughtworks.xstream;version="1.4.21", \
  com.thoughtworks.xstream.*;version="1.4.21", \
- com.sun.jersey.api.client;version="1.19.1", \
- com.sun.jersey.api.client.*;version="1.19.1", \
- com.sun.jersey.core.header;version="1.19.1", \
- com.sun.jersey.multipart;version="1.19.1", \
- javax.ws.rs.core;version="1.1.1", \
- javax.ws.rs.ext;version="1.1.1", \
  org.dom4j.*;version="${dom4j.version}", \
  org.dom4j;version="${dom4j.version}", \
  org.pentaho.metadata.*, \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -156,6 +156,7 @@ org.osgi.framework.system.packages.extra= \
  org.slf4j.*; version="${slf4j.version}", \
   org.slf4j.*; version="1.7.0", \
  org.springframework.dao; version="${spring.version}", \
+ org.springframework.aop.*; version="${spring.version}", \
  org.springframework.security.*; version="${spring-security.version}", \
  org.springframework.beans.*; version="5.3.34", \
  org.springframework.context.*; version="5.3.34", \

--- a/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/custom.properties
@@ -158,9 +158,9 @@ org.osgi.framework.system.packages.extra= \
  org.springframework.dao; version="${spring.version}", \
  org.springframework.aop.*; version="${spring.version}", \
  org.springframework.security.*; version="${spring-security.version}", \
- org.springframework.beans.*; version="5.3.34", \
- org.springframework.context.*; version="5.3.34", \
- org.springframework.core.io; version="5.3.34", \
+ org.springframework.beans.*; version="${spring.version}", \
+ org.springframework.context.*; version="${spring.version}", \
+ org.springframework.core.io; version="${spring.version}", \
  org.yaml.snakeyaml; version="${snakeyaml.version}", \
  org.yaml.snakeyaml.*; version="${snakeyaml.version}", \
  org.pentaho.database, \

--- a/assemblies/common-resources/src/main/resources/etc/jre.properties
+++ b/assemblies/common-resources/src/main/resources/etc/jre.properties
@@ -331,7 +331,6 @@ jre-9= \
  java.net.spi, \
  javax.accessibility, \
  javax.activity, \
- javax.annotation;version="1.3.2", \
  javax.annotation.processing;version="1.0", \
  javax.annotation.security;version="1.3.2", \
  javax.annotation.sql;version="1.3.2", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -50,11 +50,7 @@ org.osgi.framework.system.packages.extra= \
  com.sun.security.auth.module, \
  sun.misc, \
  com.tinkerpop.blueprints.*, \
- javax.annotation.*;version="1.2", \
- javax.servlet; version="${javax.servlet-api.version}", \
- javax.servlet.annotation; version="${javax.servlet-api.version}", \
- javax.servlet.descriptor; version="${javax.servlet-api.version}", \
- javax.servlet.http; version="${javax.servlet-api.version}", \
+ javax.annotation.*;version="1.3.1", \
  javax.servlet.jsp; version="${jsp-api.version}", \
  javax.servlet.jsp.el; version="${jsp-api.version}", \
  javax.servlet.jsp.resources; version="${jsp-api.version}", \
@@ -146,12 +142,6 @@ org.osgi.framework.system.packages.extra= \
  org.yaml.snakeyaml.*; version="${snakeyaml.version}", \
  org.pentaho.database, \
  org.pentaho.database.*, \
- com.sun.jersey.api.client;version="1.19.1", \
- com.sun.jersey.api.client.*;version="1.19.1", \
- com.sun.jersey.core.header;version="1.19.1", \
- com.sun.jersey.multipart;version="1.19.1", \
- javax.ws.rs.core;version="1.1.1", \
- javax.ws.rs.ext;version="1.1.1", \
  org.dom4j.*;version="${dom4j.version}", \
  org.dom4j;version="${dom4j.version}", \
  org.pentaho.metadata.*, \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -51,6 +51,7 @@ org.osgi.framework.system.packages.extra= \
  sun.misc, \
  com.tinkerpop.blueprints.*, \
  jakarta.servlet.*;version="${jakarta.servlet.version}", \
+ jakarta.xml.bind.*;version="${jakarta.xml.bind-api.version}",\
  javax.servlet.jsp; version="${jsp-api.version}", \
  javax.servlet.jsp.el; version="${jsp-api.version}", \
  javax.servlet.jsp.resources; version="${jsp-api.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -50,7 +50,7 @@ org.osgi.framework.system.packages.extra= \
  com.sun.security.auth.module, \
  sun.misc, \
  com.tinkerpop.blueprints.*, \
- javax.annotation.*;version="1.3.1", \
+ jakarta.servlet.*;version="${jakarta.servlet.version}", \
  javax.servlet.jsp; version="${jsp-api.version}", \
  javax.servlet.jsp.el; version="${jsp-api.version}", \
  javax.servlet.jsp.resources; version="${jsp-api.version}", \

--- a/assemblies/server/src/main/resources-filtered/etc/custom.properties
+++ b/assemblies/server/src/main/resources-filtered/etc/custom.properties
@@ -136,9 +136,9 @@ org.osgi.framework.system.packages.extra= \
  org.slf4j.*; version="1.7.0", \
  org.springframework.dao; version="${spring.version}", \
  org.springframework.security.*; version="${spring-security.version}", \
- org.springframework.beans.*; version="5.3.34", \
- org.springframework.context.*; version="5.3.34", \
- org.springframework.core.io; version="5.3.34", \
+ org.springframework.beans.*; version="${spring.version}", \
+ org.springframework.context.*; version="${spring.version}", \
+ org.springframework.core.io; version="${spring.version}", \
  org.yaml.snakeyaml; version="${snakeyaml.version}", \
  org.yaml.snakeyaml.*; version="${snakeyaml.version}", \
  org.pentaho.database, \

--- a/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
@@ -29,6 +29,8 @@
     <feature name="felix-bridge" description="Felix HTTP Bridge Service" version="${http-features-override.version}">
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.api/${felix.http.api.version}</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.bridge/${felix.http.bridge.version}</bundle>
+        <bundle dependency="true">mvn:javax.servlet/javax.servlet-api/${javax.servlet-osgi.version}</bundle>
+        <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/${jakarta.servlet-osgi.version}</bundle>
 
         <capability>http-service;provider:=felix-bridge</capability>
     </feature>

--- a/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
@@ -28,9 +28,8 @@
 
     <feature name="felix-bridge" description="Felix HTTP Bridge Service" version="${http-features-override.version}">
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.api/${felix.http.api.version}</bundle>
+        <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.servlet-api/${felix.http.api.version}</bundle>
         <bundle start-level="30">mvn:org.apache.felix/org.apache.felix.http.bridge/${felix.http.bridge.version}</bundle>
-        <bundle dependency="true">mvn:javax.servlet/javax.servlet-api/${javax.servlet-osgi.version}</bundle>
-        <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/${jakarta.servlet-osgi.version}</bundle>
 
         <capability>http-service;provider:=felix-bridge</capability>
     </feature>

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -126,6 +126,8 @@
 
   <feature name="pdi-platform" version="${project.version}">
     <bundle>mvn:pentaho/pentaho-pdi-platform/${pentaho-osgi-bundles.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-jakarta-servlet6/2.0.0-M2</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-core/2.0.0-M2</bundle>
   </feature>
 
   <feature name="pentaho-cache-system" version="1.0">

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -136,9 +136,7 @@
     <bundle>mvn:pentaho/pentaho-cache-manager-api/${pentaho-osgi-bundles.version}</bundle>
     <bundle>mvn:pentaho/guava-cache-provider/${pentaho-osgi-bundles.version}</bundle>
     <bundle>mvn:pentaho/pentaho-ehcache-provider/${pentaho-osgi-bundles.version}</bundle>
-    <bundle dependency="true">wrap:mvn:org.ehcache/jcache/${org.ehcache.version}</bundle>
     <bundle dependency="true">wrap:mvn:org.terracotta.internal/statistics/${terracotta.statistics.version}</bundle>
-    <bundle dependency="true">wrap:mvn:net.sf.ehcache.internal/ehcache-core/${net.sf.ehcache-core.version}$overwrite=merge&amp;Export-Package=net.sf.ehcache.*;version="${net.sf.ehcache-core.version}"</bundle>
     <bundle dependency="true">mvn:commons-collections/commons-collections/${commons.collections.version}</bundle>
   </feature>
 
@@ -194,8 +192,13 @@
 
     <bundle dependency="true">wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
-    <bundle dependency="true">mvn:com.hitachivantara.security.web/csrf-token-service-client-java-jax-rs-v1/${hv-security-web.version}</bundle>
+    <bundle dependency="true">mvn:com.hitachivantara.security.web/csrf-token-service-client-java-jax-rs-v2/${hv-security-web.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${pdi-data-refinery-plugin.version}</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-client/${jersey-osgi.version}</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-common/${jersey-osgi.version}</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.media/jersey-media-multipart/${jersey-osgi.version}</bundle>
+    <bundle dependency="true">mvn:org.glassfish.hk2/osgi-resource-locator/${jersey-osgi-resource-locator}</bundle>
+    <bundle dependency="true">mvn:org.jvnet.mimepull/mimepull/${mimepull-osgi.version}</bundle>
   </feature>
 
   <feature name="community-edition" version="1.0" description="Marker feature for Community Edition Builds">

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -197,7 +197,7 @@
     <bundle dependency="true">wrap:mvn:pentaho/pentaho-modeler/${pentaho-modeler.version}</bundle>
 
     <bundle dependency="true">wrap:mvn:jfree/jcommon/${jfree.jcommon.version}</bundle>
-    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${fasterxml-jackson.version}</bundle>
+    <bundle dependency="true">mvn:com.fasterxml.jackson.module/jackson-module-jakarta-xmlbind-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.hitachivantara.security.web/csrf-token-service-client-java-jax-rs-v2/${hv-security-web.version}</bundle>
     <bundle>mvn:pentaho/data-refinery-pdi-plugin/${pdi-data-refinery-plugin.version}</bundle>
     <bundle dependency="true">mvn:org.glassfish.jersey.core/jersey-client/${jersey-osgi.version}</bundle>

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -128,6 +128,10 @@
     <bundle>mvn:pentaho/pentaho-pdi-platform/${pentaho-osgi-bundles.version}</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-jakarta-servlet6/2.0.0-M2</bundle>
     <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-core/2.0.0-M2</bundle>
+    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-api/2.1.0</bundle>
+    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-client-api/2.1.0</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.ext/jersey-spring6/3.1.7</bundle>
+    <bundle dependency="true">wrap:mvn:org.gwtproject/gwt-servlet-jakarta/2.11.0$overwrite=merge&amp;Export-Package=com.google.gwt.user.server.rpc.jakarta.*;version="2.11.0"</bundle>
   </feature>
 
   <feature name="pentaho-cache-system" version="1.0">

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -126,12 +126,12 @@
 
   <feature name="pdi-platform" version="${project.version}">
     <bundle>mvn:pentaho/pentaho-pdi-platform/${pentaho-osgi-bundles.version}</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-jakarta-servlet6/2.0.0-M2</bundle>
-    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-core/2.0.0-M2</bundle>
-    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-api/2.1.0</bundle>
-    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-client-api/2.1.0</bundle>
-    <bundle dependency="true">mvn:org.glassfish.jersey.ext/jersey-spring6/3.1.7</bundle>
-    <bundle dependency="true">wrap:mvn:org.gwtproject/gwt-servlet-jakarta/2.11.0$overwrite=merge&amp;Export-Package=com.google.gwt.user.server.rpc.jakarta.*;version="2.11.0"</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-jakarta-servlet6/${commons-fileupload.version}</bundle>
+    <bundle dependency="true">mvn:org.apache.commons/commons-fileupload2-core/${commons-fileupload.version}</bundle>
+    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-api/${jakarta.websocket-api.version}</bundle>
+    <bundle dependency="true">mvn:jakarta.websocket/jakarta.websocket-client-api/${jakarta.websocket-api.version}</bundle>
+    <bundle dependency="true">mvn:org.glassfish.jersey.ext/jersey-spring6/${jersey.version}</bundle>
+    <bundle dependency="true">wrap:mvn:org.gwtproject/gwt-servlet-jakarta/${gwt-servlet-jakarta.version}$overwrite=merge&amp;Export-Package=com.google.gwt.user.server.rpc.jakarta.*;version="${gwt-servlet-jakarta.version}"</bundle>
   </feature>
 
   <feature name="pentaho-cache-system" version="1.0">

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,6 @@
     <pentaho-mongodb-plugin.version>11.0.0.0-SNAPSHOT</pentaho-mongodb-plugin.version>
     <com.github.zafarkhaja.version>0.9.0</com.github.zafarkhaja.version>
     <json.simple.version>1.1.1</json.simple.version>
-    <net.sf.ehcache-core.version>2.8.3</net.sf.ehcache-core.version>
     <terracotta.statistics.version>1.0.1</terracotta.statistics.version>
     <net.java.dev.jna.version>5.12.0</net.java.dev.jna.version>
     <icu4j.version>63.1</icu4j.version>


### PR DESCRIPTION
This pull request introduces significant updates to dependencies and system package configurations, primarily focused on transitioning from older `javax` packages to newer `jakarta` packages and modernizing the dependency versions. It also removes outdated libraries and adds new ones to align with the latest standards and frameworks.

### Transition from `javax` to `jakarta` packages:

* [`assemblies/common-resources/src/main/resources-filtered/etc/custom.properties`](diffhunk://#diff-c769f5b439d68e42360931ce7fc9a68cc7a7e44e1af6d2020fe781a8a9e908d0L68-R80): Replaced `javax.annotation`, `javax.xml.bind`, and `javax.servlet` with their `jakarta` equivalents, including `jakarta.annotation`, `jakarta.xml.bind`, and `jakarta.servlet`. Added new `jakarta.ws.rs` and `jakarta.inject` packages for enhanced support.
* [`assemblies/server/src/main/resources-filtered/etc/custom.properties`](diffhunk://#diff-9f9519ffd9d5ee2a4309402b95ca917ac67dee37fb4ed728d89f03d803130c2bL53-R54): Updated similar `javax` packages to `jakarta` versions, removing older `javax.servlet` and `javax.ws.rs` entries.

### Dependency updates and removals:

* [`features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml`](diffhunk://#diff-20e11b6f813f00ba096bcf72274987d1c866f60f90398254dd130736c55c149cR129-R134): Added new dependencies such as `commons-fileupload2`, `jakarta.websocket`, and `jersey-spring6`. Removed outdated `ehcache-core` and replaced `jackson-module-jaxb-annotations` with `jackson-module-jakarta-xmlbind-annotations`. [[1]](diffhunk://#diff-20e11b6f813f00ba096bcf72274987d1c866f60f90398254dd130736c55c149cR129-R134) [[2]](diffhunk://#diff-20e11b6f813f00ba096bcf72274987d1c866f60f90398254dd130736c55c149cL196-R207)
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L61): Removed the dependency on `net.sf.ehcache-core.version` as part of the modernization effort.

### System package version alignment:

* [`assemblies/common-resources/src/main/resources-filtered/etc/custom.properties`](diffhunk://#diff-c769f5b439d68e42360931ce7fc9a68cc7a7e44e1af6d2020fe781a8a9e908d0R159-L166): Standardized Spring Framework package versions using `${spring.version}` instead of hardcoded values. Removed older Jersey packages.
* [`assemblies/server/src/main/resources-filtered/etc/custom.properties`](diffhunk://#diff-9f9519ffd9d5ee2a4309402b95ca917ac67dee37fb4ed728d89f03d803130c2bL142-L154): Updated Spring Framework packages similarly and removed outdated Jersey packages.

### Feature enhancements:

* [`features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml`](diffhunk://#diff-f333407f71190d7a7f831d9a089d1111b679bb53d823ec1b6f531cd62146e9a2R31): Added `org.apache.felix.http.servlet-api` bundle to enhance HTTP bridge service capabilities.