### PR TITLE
[BACKLOG-43902]-Java 21 : compatibility check for Pentaho and fix Build and Run time issues while building / testing

### DIFF
--- a/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
@@ -25,6 +25,14 @@
           <allowIncompleteProjects>true</allowIncompleteProjects>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
@@ -15,4 +15,16 @@
     <karaf-maven-plugin.addBundlesToPrimaryFeature>false</karaf-maven-plugin.addBundlesToPrimaryFeature>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/features/pentaho-features/pentaho-karaf-features-server/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/pom.xml
@@ -25,6 +25,14 @@
           <allowIncompleteProjects>true</allowIncompleteProjects>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/features/pentaho-features/pentaho-karaf-features-server/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/pom.xml
@@ -15,4 +15,16 @@
     <karaf-maven-plugin.addBundlesToPrimaryFeature>false</karaf-maven-plugin.addBundlesToPrimaryFeature>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
@@ -26,4 +26,17 @@
     <karaf-maven-plugin.addBundlesToPrimaryFeature>false</karaf-maven-plugin.addBundlesToPrimaryFeature>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
@@ -36,6 +36,14 @@
           <allowIncompleteProjects>true</allowIncompleteProjects>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/overrides/pom.xml
+++ b/overrides/pom.xml
@@ -22,4 +22,16 @@
     <!-- Add the overriding bundles here to be provisioned with the karaf assembly -->
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>${maven-install-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/overrides/pom.xml
+++ b/overrides/pom.xml
@@ -32,6 +32,14 @@
           <allowIncompleteProjects>true</allowIncompleteProjects>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${maven-deploy-plugin.version}</version>
+        <configuration>
+          <allowIncompleteProjects>true</allowIncompleteProjects>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
When using JDK 21, Maven enforces stricter validation on packaging types. If a module is configured with the packaging type feature (commonly used in Eclipse/Tycho-based builds), Maven fails with an error similar to:

"The packaging plugin for project  “**** " did not assign a main file to the project but it has attachments. Change packaging to 'pom'."

This occurs because feature is not a standard packaging type recognized by core Maven plugins. As a result, Maven is unable to process the module unless special handling is applied.

To minimize disruption while preserving product integrity, the identified solution is to configure:

`<allowIncompleteProjects>true</allowIncompleteProjects>`
within the maven-install-plugin and maven-deploy-plugin only for modules with packaging type feature.

This allows the build process to proceed seamlessly under JDK 21, while preserving existing module structure and functionality