### PR TITLE
[SP-7162][PPP-6317] Removed the karaf service wrapper feature; it was…

### DIFF
--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -139,7 +139,6 @@
                 <feature>http</feature>
                 <feature>package</feature>
                 <feature>http</feature>
-                <feature>wrapper</feature>
                 <feature>cxf-jaxrs</feature>
                 <feature>war</feature>
                 <feature>package</feature>

--- a/assemblies/pmr/pom.xml
+++ b/assemblies/pmr/pom.xml
@@ -133,7 +133,6 @@
                 <feature>ssh</feature>
                 <feature>diagnostic</feature>
                 <feature>package</feature>
-                <feature>wrapper</feature>
                 <feature>cxf-jaxrs</feature>
                 <feature>pentaho-base</feature>
                 <feature>pentaho-client</feature>

--- a/assemblies/server/pom.xml
+++ b/assemblies/server/pom.xml
@@ -139,7 +139,6 @@
                 <feature>cxf-jaxrs</feature>
                 <feature>diagnostic</feature>
                 <feature>package</feature>
-                <feature>wrapper</feature>
                 <feature>pentaho-requirejs-osgi-manager</feature>
                 <feature>pentaho-webpackage</feature>
               </installedFeatures>


### PR DESCRIPTION
… unused and

contained a depenency with a GPL license. -- backport to 11.0 for 11.0.0.1 SP