### PR TITLE
build[PPP-6390][PPP-6391]: Bump bouncycastle to version 1.84

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -71,19 +71,16 @@
             originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
 
-        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <!-- PPP-6390, PPP-6391 Multiple CVEs in bcprov-jdk18on addressed in version 1.84 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcpkix-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcutil-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -73,19 +73,16 @@
             originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
 
-        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <!-- Multiple CVEs in bcprov-jdk18on addressed in version 1.84 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcutil-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bctls-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bctls-jdk18on/${bouncycastle.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"


### PR DESCRIPTION
BouncyCastle is brought in as a transitive from Apache CXF 3.6.4 (jdk18on variants).

This PR removes obsolete overrides for old artifact IDs (jdk15on/jdk15to18) and updates bundle replacements to intercept CXF's bundles, upgrading them from 1.78.1 to 1.84 to address critical CVEs.