### PR TITLE
fix[PPP-6425]: update pax-logging version to 2.2.12 in assembly.xml and pom.xml

### DIFF
--- a/assemblies/client/src/assembly/assembly.xml
+++ b/assemblies/client/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/pmr/src/assembly/assembly.xml
+++ b/assemblies/pmr/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/prd/src/assembly/assembly.xml
+++ b/assemblies/prd/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/server/src/assembly/assembly.xml
+++ b/assemblies/server/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <!-- pax-url-aether.version is in parent POM -->
     <felix.metatype.version>1.2.4</felix.metatype.version>
     <jansi.version>2.4.1</jansi.version>
-    <pax-logging.version>2.2.7</pax-logging.version>
+    <pax-logging.version>2.2.12</pax-logging.version>
     <felix.coordinator.version>1.0.2</felix.coordinator.version>
     <felix.configadmin.version>1.9.26</felix.configadmin.version>
     <felix.fileinstall.version>3.7.4</felix.fileinstall.version>


### PR DESCRIPTION
This pull request updates the version of the Pax Logging library from 2.2.7 to 2.2.12 throughout the project. The main goal is to ensure that all assemblies and the parent POM consistently use the newer version of `pax-logging`, which may include important bug fixes or security updates.

Dependency version update:

* Updated the `pax-logging.version` property from `2.2.7` to `2.2.12` in `pom.xml` to set the new default version across the project.

Assembly configuration updates:

* Updated all references to `pax-logging-log4j2` in the `excludes` section from version `2.2.7` to `2.2.12` in the following assembly files:
  - `assemblies/client/src/assembly/assembly.xml`
  - `assemblies/pmr/src/assembly/assembly.xml`
  - `assemblies/prd/src/assembly/assembly.xml`
  - `assemblies/server/src/assembly/assembly.xml`

@pentaho/tatooine_dev 