### PR TITLE
build[SP-7277]: Bump bouncycastle to version 1.84

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -71,19 +71,16 @@
             originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
 
-        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <!-- PPP-6390, PPP-6391 Multiple CVEs in bcprov-jdk18on addressed in version 1.84 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcpkix-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcutil-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -73,19 +73,16 @@
             originalUri="mvn:org.codehaus.jackson/jackson-core-asl/[1.5.0,${codehaus-jackson.version})"
             replacement="mvn:org.codehaus.jackson/jackson-core-asl/${codehaus-jackson.version}" mode="maven" />
 
-        <!-- PPP-4495 Multiple CVEs in bcprov-jdk15on addressed in version 1.65 -->
+        <!-- PPP-6390, PPP-6391 Multiple CVEs in bcprov-jdk18on addressed in version 1.84 -->
         <bundle
-            originalUri="mvn:org.bouncycastle/bcprov-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcprov-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcprov-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcprov-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcpkix-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcpkix-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcpkix-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcpkix-jdk18on/${bouncycastle.version}" mode="maven" />
         <bundle
-            originalUri="mvn:org.bouncycastle/bcutil-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcutil-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
-        <bundle
-            originalUri="mvn:org.bouncycastle/bcmail-jdk15on/[1.46,${bcprov-jdk15to18.version})"
-            replacement="mvn:org.bouncycastle/bcmail-jdk15to18/${bcprov-jdk15to18.version}" mode="maven" />
+            originalUri="mvn:org.bouncycastle/bcutil-jdk18on/[1.71.1,${bouncycastle.version})"
+            replacement="mvn:org.bouncycastle/bcutil-jdk18on/${bouncycastle.version}" mode="maven" />
 
         <bundle
             originalUri="mvn:org.ops4j.pax.logging/pax-logging-api/[1,${pax-logging.version})"


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7277 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/SP-7277)
- **Base Case:** [PPP-6391 - Backport of PPP-6391 - (10.2 Suite) CVE-2025-14813 | pdia-master has a security violation in bouncycastle](https://hv-eng.atlassian.net/browse/PPP-6391)
- **Original Master PR:** https://github.com/pentaho/pentaho-karaf-assembly/pull/846

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-karaf-assembly/pull/846
- Commit: fc3a50e365a032bdc87cb979353881915b5dbe03

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 10.2 (10.2 Suite maintenance branch)
