### PR TITLE
fix[SP-7317]: update pax-logging version to 2.2.12 in assembly.xml and pom.xml

### DIFF
--- a/assemblies/client/src/assembly/assembly.xml
+++ b/assemblies/client/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/pmr/src/assembly/assembly.xml
+++ b/assemblies/pmr/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/prd/src/assembly/assembly.xml
+++ b/assemblies/prd/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/assemblies/server/src/assembly/assembly.xml
+++ b/assemblies/server/src/assembly/assembly.xml
@@ -37,9 +37,9 @@
         <exclude>/lib/boot/</exclude>
         <exclude>/lib/ext/</exclude>
         <exclude>/lib/jdk9plus/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.7/</exclude>
-        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.7/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-api/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-log4j2/2.2.12/</exclude>
+        <exclude>/system/org/ops4j/pax/logging/pax-logging-logback/2.2.12/</exclude>
       </excludes>
     </fileSet>
   </fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <!-- pax-url-aether.version is in parent POM -->
     <felix.metatype.version>1.2.4</felix.metatype.version>
     <jansi.version>2.4.1</jansi.version>
-    <pax-logging.version>2.2.7</pax-logging.version>
+    <pax-logging.version>2.2.12</pax-logging.version>
     <felix.coordinator.version>1.0.2</felix.coordinator.version>
     <felix.configadmin.version>1.9.26</felix.configadmin.version>
     <felix.fileinstall.version>3.7.4</felix.fileinstall.version>


### PR DESCRIPTION
NOTE: This PR was created by Copilot automation.

## Backport Information
- **SP Issue:** [SP-7317 - Backport of PPP-6425 - (11.0 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/SP-7317)
- **Base Case:** [PPP-6425 - Backport of PPP-6425 - (11.0 Suite) Multiple Apache Log4j Vulnerabilities](https://hv-eng.atlassian.net/browse/PPP-6425)
- **Original Master PR:** https://github.com/pentaho/pentaho-karaf-assembly/pull/847

## Changes
- Cherry-picked from https://github.com/pentaho/pentaho-karaf-assembly/pull/847
- Commit: not provided

## Conflict Resolution
- No manual conflict resolution required

## Target
- **Target Branch:** 11.0 (11.0 Suite maintenance branch)
