### PR TITLE
fix[PPP-6483]: Remove flexjson bundle from pentaho-fasterxml Karaf feature

### DIFF
--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -164,7 +164,6 @@
   </feature>
 
   <feature name="pentaho-fasterxml" version="1.0">
-    <bundle dependency="true">wrap:mvn:net.sf.flexjson/flexjson/2.1</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-databind/${fasterxml-jackson-databind.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-annotations/${fasterxml-jackson.version}</bundle>
     <bundle dependency="true">mvn:com.fasterxml.jackson.core/jackson-core/${fasterxml-jackson.version}</bundle>


### PR DESCRIPTION
## Summary
Removes `wrap:mvn:net.sf.flexjson/flexjson/2.1` from the `pentaho-fasterxml` Karaf feature definition.

## Changes
- `features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml`: Remove the flexjson bundle entry from the `pentaho-fasterxml` feature

## Context
The `pentaho-fasterxml` feature was bundling flexjson alongside Jackson. No OSGi bundle in the distribution depends on flexjson anymore (all usages migrated to Jackson as part of PPP-6483). This was the root cause of the flexjson jar still appearing in the Karaf distribution after the code migration.