### PR TITLE
DEVO-14154: license/copyright rebrand

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Hitachi Vantara Karaf Assembly
+# Pentaho Karaf Assembly
 This project builds and assembles the customized Pentaho Karaf Assembly.
 
 ### Development

--- a/assemblies/README.md
+++ b/assemblies/README.md
@@ -1,4 +1,4 @@
-# Hitachi Vantara Karaf Assembly
+# Pentaho Karaf Assembly
 This project is responsible for building custom Karaf assemblies using the new way.
 This project is currently creating assemblies to Community Edition of the following products:
 * PDI

--- a/assemblies/client/pom.xml
+++ b/assemblies/client/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/client/src/assembly/assembly.xml
+++ b/assemblies/client/src/assembly/assembly.xml
@@ -1,19 +1,15 @@
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <assembly  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/assemblies/client/src/main/resources/config/README
+++ b/assemblies/client/src/main/resources/config/README
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2019 - 2026 Pentaho. All rights reserved.
  */
 
 This folder is intended to be used to deploy into the Karaf container exploded

--- a/assemblies/client/src/main/resources/etc/KarafPorts.yaml
+++ b/assemblies/client/src/main/resources/etc/KarafPorts.yaml
@@ -1,3 +1,14 @@
+# ******************************************************************************
+#
+# Pentaho
+#
+# Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE.TXT file.
+#
+# Change Date: 2030-06-15
+# ******************************************************************************
 Service:
  - serviceName: karaf
    serviceDescription: Karaf service ports

--- a/assemblies/common-resources/pom.xml
+++ b/assemblies/common-resources/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0" xmlns:f="http://karaf.apache.org/xmlns/features/v1.6.0">
 
     <!-- A list of blacklisted features XML repository URIs - they can't be added later -->

--- a/assemblies/common-resources/src/main/resources/etc/KarafPorts.yaml
+++ b/assemblies/common-resources/src/main/resources/etc/KarafPorts.yaml
@@ -1,3 +1,14 @@
+# ******************************************************************************
+#
+# Pentaho
+#
+# Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE.TXT file.
+#
+# Change Date: 2030-06-15
+# ******************************************************************************
 Service:
  - serviceName: karaf
    serviceDescription: Karaf service ports

--- a/assemblies/pme/pom.xml
+++ b/assemblies/pme/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/pme/src/assembly/assembly.xml
+++ b/assemblies/pme/src/assembly/assembly.xml
@@ -1,19 +1,15 @@
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <assembly  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/assemblies/pmr/pom.xml
+++ b/assemblies/pmr/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/pmr/src/assembly/assembly.xml
+++ b/assemblies/pmr/src/assembly/assembly.xml
@@ -1,19 +1,15 @@
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <assembly  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/prd/pom.xml
+++ b/assemblies/prd/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/prd/src/assembly/assembly.xml
+++ b/assemblies/prd/src/assembly/assembly.xml
@@ -1,19 +1,15 @@
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <assembly  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/assemblies/server/pom.xml
+++ b/assemblies/server/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/assemblies/server/src/assembly/assembly.xml
+++ b/assemblies/server/src/assembly/assembly.xml
@@ -1,19 +1,15 @@
-<!--
-    ~ This program is free software; you can redistribute it and/or modify it under the
-    ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-    ~ Foundation.
-    ~
-    ~ You should have received a copy of the GNU Lesser General Public License along with this
-    ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-    ~ or from the Free Software Foundation, Inc.,
-    ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-    ~
-    ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-    ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-    ~ See the GNU Lesser General Public License for more details.
-    ~
-    ~ Copyright 2014 - 2019 Hitachi Vantara. All rights reserved.
-    -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <assembly  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0" xmlns:f="http://karaf.apache.org/xmlns/features/v1.6.0">
 
     <!-- A list of blacklisted features XML repository URIs - they can't be added later -->

--- a/assemblies/server/src/main/resources/config/README
+++ b/assemblies/server/src/main/resources/config/README
@@ -12,7 +12,7 @@
  * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU Lesser General Public License for more details.
  *
- * Copyright (c) 2019 Hitachi Vantara. All rights reserved.
+ * Copyright (c) 2019 - 2026 Pentaho. All rights reserved.
  */
 
 This folder is intended to be used to deploy into the Karaf container exploded

--- a/assemblies/server/src/main/resources/config/web-client/client-config-enabler-require-js-cfg.js
+++ b/assemblies/server/src/main/resources/config/web-client/client-config-enabler-require-js-cfg.js
@@ -2,13 +2,14 @@
  *
  * Pentaho
  *
- * Copyright (C) 2024 by Hitachi Vantara, LLC : http://www.pentaho.com
+ * Copyright (C) 2024 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
  *
  * Use of this software is governed by the Business Source License included
  * in the LICENSE.TXT file.
  *
- * Change Date: 2029-07-20
+ * Change Date: 2030-06-15
  ******************************************************************************/
+
 
 (function() {
   /* globals requireCfg, CONTEXT_PATH */

--- a/assemblies/server/src/main/resources/etc/KarafPorts.yaml
+++ b/assemblies/server/src/main/resources/etc/KarafPorts.yaml
@@ -1,3 +1,14 @@
+# ******************************************************************************
+#
+# Pentaho
+#
+# Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+#
+# Use of this software is governed by the Business Source License included
+# in the LICENSE.TXT file.
+#
+# Change Date: 2030-06-15
+# ******************************************************************************
 Service:
  - serviceName: karaf
    serviceDescription: Karaf service ports

--- a/assemblies/server/src/main/resources/plugin.xml
+++ b/assemblies/server/src/main/resources/plugin.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <plugin title="Plugin to enable the global configuration for VizAPI 3.0">
   <!--
     BACKLOG-20839: the karaf folder is tagged as a platform plugin in order to

--- a/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-enterprise/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/features/pentaho-features/pentaho-karaf-features-enterprise/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-enterprise/src/main/feature/feature.xml
@@ -1,19 +1,15 @@
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2021 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <features name="pentaho-karaf-features-enterprise"
   xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">

--- a/features/pentaho-features/pentaho-karaf-features-server/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-server/src/main/feature/feature.xml
@@ -1,19 +1,15 @@
-<!--
- ~ This program is free software; you can redistribute it and/or modify it under the
- ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- ~ Foundation.
- ~
- ~ You should have received a copy of the GNU Lesser General Public License along with this
- ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- ~ or from the Free Software Foundation, Inc.,
- ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- ~
- ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- ~ See the GNU Lesser General Public License for more details.
- ~
- ~ Copyright 2014 - 2021 Hitachi Vantara. All rights reserved.
- -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <features name="pentaho-karaf-features-server" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
     <repository>mvn:org.pentaho/pentaho-requirejs-osgi-manager/${pentaho-osgi-bundles.version}/xml/features</repository>

--- a/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
+++ b/features/pentaho-features/pentaho-karaf-features-standard/src/main/feature/feature.xml
@@ -1,19 +1,15 @@
-<!--
- ~ This program is free software; you can redistribute it and/or modify it under the
- ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- ~ Foundation.
- ~
- ~ You should have received a copy of the GNU Lesser General Public License along with this
- ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- ~ or from the Free Software Foundation, Inc.,
- ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- ~
- ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- ~ See the GNU Lesser General Public License for more details.
- ~
- ~ Copyright 2017 - 2019 Hitachi Vantara. All rights reserved.
- -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2017 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <features name="pentaho-karaf-features-standard" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
   <repository>mvn:org.pentaho/pentaho-osgi-utils/${pentaho-osgi-bundles.version}/xml/features</repository>

--- a/features/pentaho-features/pom.xml
+++ b/features/pentaho-features/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/overrides/pom.xml
+++ b/overrides/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/overrides/src/main/feature/feature.xml
+++ b/overrides/src/main/feature/feature.xml
@@ -1,19 +1,15 @@
-<!--
- ~ This program is free software; you can redistribute it and/or modify it under the
- ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- ~ Foundation.
- ~
- ~ You should have received a copy of the GNU Lesser General Public License along with this
- ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- ~ or from the Free Software Foundation, Inc.,
- ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- ~
- ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- ~ See the GNU Lesser General Public License for more details.
- ~
- ~ Copyright 2017 Hitachi Vantara. All rights reserved.
- -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2017 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <features name="${project.artifactId}-repo" xmlns="http://karaf.apache.org/xmlns/features/v1.2.1">
   <feature name="${project.artifactId}" version="${project.version}">

--- a/pentaho-blueprint-activators/pom.xml
+++ b/pentaho-blueprint-activators/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/pentaho-blueprint-activators/src/main/resources/krb5-jaas.xml
+++ b/pentaho-blueprint-activators/src/main/resources/krb5-jaas.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2017 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2017 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pentaho-blueprint-activators/src/main/resources/monitoring-snmp.xml
+++ b/pentaho-blueprint-activators/src/main/resources/monitoring-snmp.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  ~ This program is free software; you can redistribute it and/or modify it under the
-  ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
-  ~ Foundation.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public License along with this
-  ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-  ~ or from the Free Software Foundation, Inc.,
-  ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-  ~
-  ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
-  ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ~ See the GNU Lesser General Public License for more details.
-  ~
-  ~ Copyright 2014 - 2017 Hitachi Vantara. All rights reserved.
-  -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pentaho-blueprint-activators/src/main/resources/proxy-watcher.xml
+++ b/pentaho-blueprint-activators/src/main/resources/proxy-watcher.xml
@@ -1,20 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
- ~ This program is free software; you can redistribute it and/or modify it under the
- ~ terms of the GNU Lesser General Public License, version 2.1 as published by the Free Software
- ~ Foundation.
- ~
- ~ You should have received a copy of the GNU Lesser General Public License along with this
- ~ program; if not, you can obtain a copy at http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
- ~ or from the Free Software Foundation, Inc.,
- ~ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- ~
- ~ This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- ~ without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- ~ See the GNU Lesser General Public License for more details.
- ~
- ~ Copyright 2014 - 2017 Hitachi Vantara. All rights reserved.
- -->
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2014 - 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
+
 
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pentaho-blueprint-activators/src/main/resources/standard.xml
+++ b/pentaho-blueprint-activators/src/main/resources/standard.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
            xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0">
 

--- a/pentaho-osgi-config/pom.xml
+++ b/pentaho-osgi-config/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- ******************************************************************************
+ *
+ * Pentaho
+ *
+ * Copyright (C) 2026 by Pentaho Canada Inc. : http://www.pentaho.com
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file.
+ *
+ * Change Date: 2030-06-15
+ ******************************************************************************* -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
          xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">


### PR DESCRIPTION
Automated license header and brand update (see update-reports/). Generated and locally validated by updater.py, published by publish_branches.py.