### PR TITLE
[CVE-2026-56452] Override sshd-scp bundle to 2.19.0 in the karaf assembly

### DIFF
--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -107,6 +107,15 @@
                 originalUri="mvn:org.apache.mina/mina-core/[0,${mina-core.version})"
                 replacement="mvn:org.apache.mina/mina-core/${mina-core.version}" mode="maven" />
 
+        <!-- [CVE-2026-56452] Path traversal in the sshd-scp component of Apache MINA SSHD.
+             The ssh feature (installed in assemblies/server) resolves org.apache.sshd bundles
+             from the upstream org.hitachivantara.karaf.features Karaf 4.4.6 feature repo, not
+             from maven-parent-poms' apache-sshd.version-managed dependencies, so it is fixed
+             independently here. Addressed in Apache MINA SSHD 2.19.0. -->
+        <bundle
+                originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
+                replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
+
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->

--- a/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/common-resources/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -113,8 +113,8 @@
              from maven-parent-poms' apache-sshd.version-managed dependencies, so it is fixed
              independently here. Addressed in Apache MINA SSHD 2.19.0. -->
         <bundle
-                originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
-                replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
+            originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
+            replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
 
     </bundleReplacements>
 

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -115,8 +115,8 @@
              maven-parent-poms' apache-sshd.version-managed dependencies, so it is fixed
              independently here. Addressed in Apache MINA SSHD 2.19.0. -->
         <bundle
-                originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
-                replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
+            originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
+            replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
 
     </bundleReplacements>
 

--- a/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
+++ b/assemblies/server/src/main/resources-filtered/etc/org.apache.karaf.features.xml
@@ -109,6 +109,15 @@
                 originalUri="mvn:org.apache.mina/mina-core/[0,${mina-core.version})"
                 replacement="mvn:org.apache.mina/mina-core/${mina-core.version}" mode="maven" />
 
+        <!-- [CVE-2026-56452] Path traversal in the sshd-scp component of Apache MINA SSHD.
+             The ssh feature (installed below) resolves org.apache.sshd bundles from the
+             upstream org.hitachivantara.karaf.features Karaf 4.4.6 feature repo, not from
+             maven-parent-poms' apache-sshd.version-managed dependencies, so it is fixed
+             independently here. Addressed in Apache MINA SSHD 2.19.0. -->
+        <bundle
+                originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
+                replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
+
     </bundleReplacements>
 
     <!-- A list of feature replacements that allows changing external feature definitions -->


### PR DESCRIPTION
## CVE-2026-56452 — Path traversal in the sshd-scp component of Apache MINA SSHD

**Component:** `org.apache.sshd:sshd-scp` @ 2.12.1 (maven)
**Fixed version:** 2.19.0
**Severity:** High | CVSS 7.5 | CWE-22, CWE-73

The SCP "C"/"D" command handler did not validate filenames, letting a malicious sender write files to attacker-controlled paths. Fixed upstream in Apache MINA SSHD 2.19.0. Ships in `pentaho-server(-manual)-ee/ce` under `.../karaf/system/org/apache/sshd/sshd-scp/2.12.1/`.

### Root cause / why this isn't a maven-parent-poms fix

Unlike `sshd-core`/`sshd-sftp` (used directly by `pentaho-kettle`, `big-data-plugin`, `pme`, `prd` and managed via `maven-parent-poms`' `apache-sshd.version` property — see companion PR pentaho/maven-parent-poms#936 for CVE-2026-56624), `sshd-scp` in the karaf system directory comes from the `ssh` feature installed by `assemblies/server` (`installedFeatures`), which resolves `org.apache.sshd` bundles from the upstream `org.hitachivantara.karaf.features` Karaf 4.4.6 feature repo — independent of Pentaho's own managed Maven dependencies.

### Fix

Added a `bundleReplacement` forcing `org.apache.sshd:sshd-scp` to `${apache-sshd.version}` (2.19.0) in both the `common-resources` and `server` copies of `etc/org.apache.karaf.features.xml`, following the exact existing precedent already in this file (PPP-5077 `mina-core`, PPP-4654 `commons-io`).

```xml
<bundle
    originalUri="mvn:org.apache.sshd/sshd-scp/[0,${apache-sshd.version})"
    replacement="mvn:org.apache.sshd/sshd-scp/${apache-sshd.version}" mode="maven" />
```

### Verification

- Confirmed via org-wide code search that `apache-sshd.version` is defined once, centrally, in `maven-parent-poms` and inherited through this repo's parent chain.
- `mvn help:evaluate -Dexpression=apache-sshd.version` on `assemblies/server` resolves to `2.19.0` (against a locally patched parent), confirming the placeholder resolves correctly at build time.
- Both edited XML files validated as well-formed.
- A full `karaf-assembly` packaging build (requiring the `karaf-maven-plugin` lifecycle) was not run locally; CI plus a later re-analysis of the `pdia-master` build will confirm the vulnerable `sshd-scp` version is absent end-to-end, per the standard verification model.

---
Produced by `codemedic-local-remediator`, reviewed locally with the developer before push.

<!-- codemedic-remediation {"build": "pdia-master@11.1.0.0-377", "items": [{"cve": "CVE-2026-56452", "coordinate": "org.apache.sshd:sshd-scp"}]} -->
